### PR TITLE
ci: add build check on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          SUPABASE_SERVICE_ROLE_KEY: placeholder
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_placeholder
+          CLERK_SECRET_KEY: sk_test_placeholder
+          PLAID_CLIENT_ID: placeholder
+          PLAID_PRODUCTION_SECRET: placeholder
+          PLAID_SANDBOX_SECRET: placeholder
+          PLAID_ENV: sandbox
+          GOOGLE_CLIENT_ID: placeholder
+          GOOGLE_CLIENT_SECRET: placeholder
+          GOOGLE_REDIRECT_URI: http://localhost:3000/api/gmail/callback
+          STRIPE_SECRET_KEY: sk_test_placeholder
+          STRIPE_WEBHOOK_SECRET: whsec_placeholder
+          APP_URL: http://localhost:3000


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs `npm ci && npm run build` on every PR targeting `main`
- Uses placeholder env vars so the Next.js build can compile without real secrets
- This needs to be merged first so CI checks apply to all subsequent PRs (including #9)

## Test plan

- [ ] Verify the workflow file is valid YAML
- [ ] Once merged, open/re-push a PR and confirm the "Build" check appears

Made with [Cursor](https://cursor.com)