### PR TITLE
fix: use valid Clerk key in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           SUPABASE_SERVICE_ROLE_KEY: placeholder
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_placeholder
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_YWJzb2x1dGUtbGVtdXItNjguY2xlcmsuYWNjb3VudHMuZGV2JA
           CLERK_SECRET_KEY: sk_test_placeholder
           PLAID_CLIENT_ID: placeholder
           PLAID_PRODUCTION_SECRET: placeholder


### PR DESCRIPTION
## Summary

- Use the real Clerk publishable key (public, not a secret) in the CI workflow so `next build` can initialize ClerkProvider during static page generation
- The previous placeholder `pk_test_placeholder` failed Clerk's format validation, causing the build to error out on every PR

## Test plan

- [ ] CI build passes on this PR (self-validating)

Made with [Cursor](https://cursor.com)