### PR TITLE
feat: support mobile deep link redirect in Gmail OAuth

### DIFF
--- a/app/api/gmail/auth/route.ts
+++ b/app/api/gmail/auth/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getAuthUrl } from "@/lib/google-auth";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const { userId } = await auth();
   console.log("[Gmail Auth] Starting OAuth flow for user:", userId);
 
@@ -12,7 +12,8 @@ export async function GET() {
   }
 
   try {
-    const authUrl = getAuthUrl(userId);
+    const redirect = request.nextUrl.searchParams.get("redirect") || undefined;
+    const authUrl = getAuthUrl(userId, redirect);
     console.log("[Gmail Auth] Generated auth URL:", authUrl);
     return NextResponse.json({ authUrl });
   } catch (e) {

--- a/app/api/gmail/callback/route.ts
+++ b/app/api/gmail/callback/route.ts
@@ -2,22 +2,34 @@ import { NextRequest, NextResponse } from "next/server";
 import { exchangeCode, saveGmailTokens, getOAuth2Client } from "@/lib/google-auth";
 import { google } from "googleapis";
 
+function parseOAuthState(raw: string): { userId: string; redirect?: string } {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed.userId) return parsed;
+  } catch {
+    // Legacy format: state is just the clerkUserId string
+  }
+  return { userId: raw };
+}
+
 export async function GET(request: NextRequest) {
   console.log("[Gmail Callback] Starting OAuth callback processing");
 
   const code = request.nextUrl.searchParams.get("code");
-  const clerkUserId = request.nextUrl.searchParams.get("state");
+  const rawState = request.nextUrl.searchParams.get("state");
 
   console.log("[Gmail Callback] Received:", {
     hasCode: !!code,
-    clerkUserId,
+    rawState,
     codeLength: code?.length
   });
 
-  if (!code || !clerkUserId) {
+  if (!code || !rawState) {
     console.error("[Gmail Callback] Missing code or state");
     return NextResponse.redirect(new URL("/app/email-receipts?error=missing_params", request.url));
   }
+
+  const { userId: clerkUserId, redirect: mobileRedirect } = parseOAuthState(rawState);
 
   try {
     console.log("[Gmail Callback] Exchanging code for tokens...");
@@ -28,7 +40,6 @@ export async function GET(request: NextRequest) {
       expiryDate: tokens.expiry_date
     });
 
-    // Get the user's email from Gmail profile
     let email: string | undefined;
     try {
       console.log("[Gmail Callback] Fetching user email...");
@@ -46,10 +57,20 @@ export async function GET(request: NextRequest) {
     await saveGmailTokens(clerkUserId, tokens, email);
     console.log("[Gmail Callback] Tokens saved successfully");
 
-    // Redirect to email-receipts page with success message
+    if (mobileRedirect) {
+      const url = `${mobileRedirect}?connected=true`;
+      console.log("[Gmail Callback] Redirecting to mobile app:", url);
+      return NextResponse.redirect(url);
+    }
+
     return NextResponse.redirect(new URL("/app/email-receipts?connected=true", request.url));
   } catch (e) {
     console.error("[Gmail Callback] Token exchange failed:", e);
+
+    if (mobileRedirect) {
+      return NextResponse.redirect(`${mobileRedirect}?error=auth_failed`);
+    }
+
     return NextResponse.redirect(new URL("/app/email-receipts?error=auth_failed", request.url));
   }
 }

--- a/lib/google-auth.ts
+++ b/lib/google-auth.ts
@@ -13,13 +13,16 @@ export function getOAuth2Client() {
   return new google.auth.OAuth2(clientId, clientSecret, redirectUri);
 }
 
-export function getAuthUrl(clerkUserId: string): string {
+export function getAuthUrl(clerkUserId: string, mobileRedirect?: string): string {
   const client = getOAuth2Client();
+  const state = mobileRedirect
+    ? JSON.stringify({ userId: clerkUserId, redirect: mobileRedirect })
+    : clerkUserId;
   return client.generateAuthUrl({
     access_type: "offline",
     scope: SCOPES,
     prompt: "consent",
-    state: clerkUserId,
+    state,
   });
 }
 


### PR DESCRIPTION
## Summary

- Gmail auth route now accepts optional `?redirect=` query param for mobile deep linking
- OAuth callback parses redirect URL from state and redirects to the mobile app (`coconut://gmail-callback`) when present
- Fully backwards compatible — existing web flow is unchanged (state falls back to plain userId string)

## Test plan

- [ ] Web Gmail connect flow still works (no redirect param = same behavior)
- [ ] Mobile flow: pass `?redirect=coconut://gmail-callback` to `/api/gmail/auth`, verify callback redirects to the deep link

Made with [Cursor](https://cursor.com)