### PR TITLE
fix: E2E test setup — load .env.local, validate Clerk keys, skip gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,10 @@ Thumbs.db
 # Vercel
 .vercel
 
+# Playwright
+test-results/
+playwright-report/
+screenshots/
+
 # clerk configuration (can include secrets)
 /.clerk/

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,16 +1,51 @@
 import { clerkSetup } from "@clerk/testing/playwright";
+import { loadEnvConfig } from "@next/env";
+import { writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { join } from "path";
+
+export const CLERK_READY_MARKER = join(
+  process.cwd(), "node_modules", ".cache", ".clerk-e2e-ready",
+);
 
 export default async function globalSetup() {
-  // clerkSetup requires CLERK_PUBLISHABLE_KEY in the environment.
-  // In keyless/dev mode Clerk auto-generates a temporary key but doesn't
-  // set it as an env var. If missing, skip Clerk testing setup — individual
-  // tests will call setupClerkTestingToken which handles this gracefully.
-  if (!process.env.CLERK_PUBLISHABLE_KEY) {
-    console.warn(
-      "[e2e] CLERK_PUBLISHABLE_KEY not set — skipping clerkSetup. " +
-        "Set it in .env.local to enable authenticated E2E tests."
-    );
+  loadEnvConfig(process.cwd());
+
+  try { unlinkSync(CLERK_READY_MARKER); } catch {}
+
+  if (!process.env.CLERK_PUBLISHABLE_KEY && process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+    process.env.CLERK_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  }
+
+  if (!process.env.CLERK_PUBLISHABLE_KEY || !process.env.CLERK_SECRET_KEY) {
+    console.warn("[e2e] Clerk keys missing — authenticated tests will be skipped.");
     return;
   }
-  await clerkSetup();
+
+  // Verify the server accepts the secret key before running clerkSetup.
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+  try {
+    const probe = await fetch(`${baseURL}/api/debug/me`, { redirect: "manual" });
+    if (probe.status === 500) {
+      console.warn(
+        "[e2e] Server returned 500 — CLERK_SECRET_KEY may be invalid. " +
+          "Authenticated tests will be skipped.",
+      );
+      return;
+    }
+  } catch {
+    // Server not reachable yet — Playwright's webServer will start it
+  }
+
+  try {
+    await Promise.race([
+      clerkSetup(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("clerkSetup timed out (15 s)")), 15_000),
+      ),
+    ]);
+    mkdirSync(join(process.cwd(), "node_modules", ".cache"), { recursive: true });
+    writeFileSync(CLERK_READY_MARKER, Date.now().toString());
+  } catch (err) {
+    console.warn(`[e2e] clerkSetup failed — authenticated tests will be skipped: ${err}`);
+  }
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,24 +1,26 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { type Page, test } from "@playwright/test";
+import { existsSync } from "fs";
+import { join } from "path";
 
-const clerkConfigured = !!process.env.CLERK_PUBLISHABLE_KEY;
+const CLERK_READY_MARKER = join(
+  process.cwd(), "node_modules", ".cache", ".clerk-e2e-ready",
+);
 
-/**
- * Injects the Clerk testing token so the browser session is treated as
- * authenticated by the Clerk middleware. Call once per test before navigation.
- */
-export async function authenticatePage(page: Page) {
-  await setupClerkTestingToken({ page });
+function isClerkReady(): boolean {
+  return existsSync(CLERK_READY_MARKER);
 }
 
 /**
  * Navigate to a protected route with authentication.
- * Waits for the page to finish loading after navigation.
- * Skips the test when CLERK_PUBLISHABLE_KEY is not configured.
+ * Skips when clerkSetup() did not complete (missing/invalid keys).
  */
 export async function goAuthenticated(page: Page, path: string) {
-  test.skip(!clerkConfigured, "CLERK_PUBLISHABLE_KEY not set — skipping authenticated test");
-  await authenticatePage(page);
+  test.skip(
+    !isClerkReady(),
+    "Clerk not configured (clerkSetup failed or keys missing) — skipping",
+  );
+  await setupClerkTestingToken({ page });
   await page.goto(path);
   await page.waitForLoadState("domcontentloaded");
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
+import { loadEnvConfig } from "@next/env";
+
+loadEnvConfig(process.cwd());
+
+if (!process.env.CLERK_PUBLISHABLE_KEY && process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+  process.env.CLERK_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+}
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -15,12 +23,10 @@ export default defineConfig({
     screenshot: "only-on-failure",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
-  webServer: process.env.CI
-    ? {
-        command: "npm run build && npm run start",
-        url: "http://localhost:3000",
-        timeout: 120_000,
-        reuseExistingServer: false,
-      }
-    : undefined,
+  webServer: {
+    command: "npm run build && npm run start",
+    url: "http://localhost:3000",
+    timeout: 120_000,
+    reuseExistingServer: true,
+  },
 });


### PR DESCRIPTION
## Summary

- **Loads `.env.local` via `@next/env`** in both `playwright.config.ts` and `e2e/global-setup.ts` so Playwright picks up Clerk keys without manual export
- **Bridges `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` → `CLERK_PUBLISHABLE_KEY`** since Next.js uses the prefixed name but `@clerk/testing` expects the unprefixed one
- **Validates the secret key** by probing the running server before calling `clerkSetup()` — if the server returns 500 (invalid key), authenticated tests skip instead of failing or hanging
- **Adds a 15s timeout** to `clerkSetup()` to prevent infinite hangs when Clerk's API is unreachable or keys are misconfigured
- **Uses a marker file** (`node_modules/.cache/.clerk-e2e-ready`) to reliably communicate clerkSetup success to Playwright worker processes
- **Always reuses existing server** (`reuseExistingServer: true`) — locally it uses your running `npm run dev`, in CI nothing is running so it builds and starts one
- **Adds `test-results/`, `playwright-report/`, `screenshots/`** to `.gitignore`

## Test plan

- [ ] Run `npx playwright test` locally with valid Clerk keys → authenticated tests should run
- [ ] Run `npx playwright test` locally with missing/invalid keys → authenticated tests should skip, unauthenticated tests should pass
- [ ] CI pipeline passes with placeholder keys (authenticated tests skip, rest pass)


Made with [Cursor](https://cursor.com)