### PR TITLE
fix: guard subscriptions API and UI against null/undefined values

### DIFF
--- a/app/api/subscriptions/route.ts
+++ b/app/api/subscriptions/route.ts
@@ -8,8 +8,18 @@ import {
 } from "@/lib/subscription-detect";
 import { getEffectiveUserId } from "@/lib/demo";
 
-function addMonth(dateStr: string): string {
+function addMonth(dateStr: string | null | undefined): string {
+  if (!dateStr || typeof dateStr !== "string") {
+    const fallback = new Date();
+    fallback.setMonth(fallback.getMonth() + 1);
+    return fallback.toISOString().slice(0, 10);
+  }
   const d = new Date(dateStr + "T12:00:00");
+  if (isNaN(d.getTime())) {
+    const fallback = new Date();
+    fallback.setMonth(fallback.getMonth() + 1);
+    return fallback.toISOString().slice(0, 10);
+  }
   d.setMonth(d.getMonth() + 1);
   return d.toISOString().slice(0, 10);
 }
@@ -23,7 +33,7 @@ export async function GET() {
     const db = getSupabase();
     const { data, error } = await db.from("subscriptions").select("id, merchant_name, amount, frequency, last_charge_date, next_due_date, primary_category, transaction_count, status").eq("clerk_user_id", effectiveUserId).eq("status", "active").order("amount", { ascending: false });
     if (error) throw error;
-    const subs = (data ?? []).map((s) => ({ id: s.id, merchant: s.merchant_name, amount: Number(s.amount), frequency: s.frequency, lastCharged: s.last_charge_date, nextDue: s.next_due_date, category: (s.primary_category ?? "SUBSCRIPTIONS").replace(/_/g, " "), transactionCount: s.transaction_count ?? 0, status: s.status }));
+    const subs = (data ?? []).map((s) => ({ id: s.id, merchant: s.merchant_name ?? "Unknown", amount: Number(s.amount) || 0, frequency: s.frequency ?? "monthly", lastCharged: s.last_charge_date ?? null, nextDue: s.next_due_date ?? null, category: (s.primary_category ?? "SUBSCRIPTIONS").replace(/_/g, " "), transactionCount: s.transaction_count ?? 0, status: s.status ?? "active" }));
     return NextResponse.json(subs);
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Failed" }, { status: 500 });

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -11,7 +11,7 @@ function MerchantAvatar({ name, color }: { name: string; color: string }) {
       className="w-10 h-10 rounded-xl flex items-center justify-center text-white text-sm font-bold shrink-0"
       style={{ backgroundColor: color }}
     >
-      {name[0]}
+      {name ? name[0] : "?"}
     </div>
   );
 }
@@ -79,7 +79,7 @@ export default function SubscriptionsPage() {
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-semibold text-gray-900">{sub.merchant}</div>
                   <div className="flex items-center gap-2 text-xs text-gray-400">
-                    {sub.category} · Last: {sub.lastChargedStr}
+                    {sub.category ?? "—"} · Last: {sub.lastChargedStr ?? "—"}
                   </div>
                 </div>
                 <div className="text-right shrink-0">

--- a/hooks/useSubscriptions.ts
+++ b/hooks/useSubscriptions.ts
@@ -7,8 +7,8 @@ export interface Subscription {
   merchant: string;
   amount: number;
   frequency: string;
-  lastCharged: string;
-  nextDue: string;
+  lastCharged: string | null;
+  nextDue: string | null;
   category: string;
   transactionCount: number;
   status: string;
@@ -16,14 +16,17 @@ export interface Subscription {
 
 const MERCHANT_COLORS = ["#E50914", "#1DB954", "#00674B", "#FF9900", "#003366", "#7BB848", "#555555", "#4A6CF7", "#E8507A", "#F59E0B", "#10A37F", "#FF5A5F", "#1A1A1A", "#4A90D9"];
 
-function hashColor(str: string): string {
+function hashColor(str: string | null | undefined): string {
+  if (!str) return MERCHANT_COLORS[0];
   let h = 0;
   for (let i = 0; i < str.length; i++) h = (h << 5) - h + str.charCodeAt(i);
   return MERCHANT_COLORS[Math.abs(h) % MERCHANT_COLORS.length];
 }
 
-function fmtDate(dateStr: string): string {
+function fmtDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return "—";
   const d = new Date(dateStr + "T12:00:00");
+  if (isNaN(d.getTime())) return "—";
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
   return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
 }


### PR DESCRIPTION
## Summary
- Guards `addMonth()` against null/invalid date strings that caused `RangeError` crashes
- API response now uses null coalescing so `merchant`, `amount`, `frequency` never leak as null/undefined
- `fmtDate()` returns "—" instead of rendering "undefined NaN, NaN" for null dates
- `MerchantAvatar` shows "?" fallback for null merchant names

Closes #18

## Test plan
- [ ] Load subscriptions page with bank linked — values display correctly
- [ ] Verify no "undefined" text appears in subscription cards
- [ ] Mark a transaction as subscription when date is present — works as before

Made with [Cursor](https://cursor.com)