### PR TITLE
fix: receipt page shows single-group label and improves upload accessibility

### DIFF
--- a/app/app/receipt/page.tsx
+++ b/app/app/receipt/page.tsx
@@ -149,6 +149,10 @@ function UploadStep({ rs }: { rs: ReturnType<typeof useReceiptSplit> }) {
         onDragLeave={() => setDragOver(false)}
         onDrop={handleDrop}
         onClick={() => fileRef.current?.click()}
+        role="button"
+        aria-label="Upload receipt image"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") fileRef.current?.click(); }}
         className={`relative border-2 border-dashed rounded-2xl p-12 text-center cursor-pointer transition-all ${
           dragOver
             ? "border-[#3D8E62] bg-[#EEF7F2]"
@@ -928,7 +932,7 @@ function SummaryStep({ rs }: { rs: ReturnType<typeof useReceiptSplit> }) {
           </div>
 
           <div className="space-y-3">
-            {groups.length > 1 && (
+            {groups.length > 1 ? (
               <select
                 value={selectedGroupId}
                 onChange={(e) => setSelectedGroupId(e.target.value)}
@@ -941,7 +945,11 @@ function SummaryStep({ rs }: { rs: ReturnType<typeof useReceiptSplit> }) {
                   </option>
                 ))}
               </select>
-            )}
+            ) : groups.length === 1 ? (
+              <div className="px-3 py-2 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-xl">
+                Saving to: <span className="font-medium">{groups[0].name}</span>
+              </div>
+            ) : null}
 
             <button
               onClick={handleFinish}


### PR DESCRIPTION
## Summary
- Shows "Saving to: {group name}" when only one group exists, instead of hiding the selector entirely
- Adds `role="button"`, `aria-label="Upload receipt image"`, and keyboard support to the drop zone
- Multi-group select behavior unchanged

Closes #22

## Test plan
- [ ] With one group: receipt summary shows "Saving to: {name}" label
- [ ] With multiple groups: group selector dropdown works as before
- [ ] Drop zone is keyboard-accessible (Tab to focus, Enter/Space to open file picker)

Made with [Cursor](https://cursor.com)