### PR TITLE
perf: optimize queries — batch upserts, pagination, narrow selects

### DIFF
--- a/app/api/groups/summary/route.ts
+++ b/app/api/groups/summary/route.ts
@@ -41,7 +41,8 @@ export async function GET() {
       transactions(amount)
     `)
     .in("group_id", groupIds)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .limit(500);
 
   const splitIds = (splits ?? []).map((s) => s.id);
 

--- a/app/api/plaid/accounts/route.ts
+++ b/app/api/plaid/accounts/route.ts
@@ -64,7 +64,7 @@ export async function GET() {
     const db = getSupabase();
     const { data: cached } = await db
       .from("accounts")
-      .select("*")
+      .select("id, plaid_account_id, name, type, subtype, mask, balance_current, balance_available, iso_currency_code")
       .eq("clerk_user_id", userId);
 
     if (cached && cached.length > 0) {
@@ -94,20 +94,25 @@ export async function GET() {
     if (!client) return NextResponse.json({ error: "Plaid not configured" }, { status: 503 });
 
     const response = await client.accountsGet({ access_token: accessToken });
-    // Upsert to ensure we have DB ids (for transaction filtering)
-    for (const acct of response.data.accounts) {
+    // Batch upsert all accounts in one call
+    const rows = response.data.accounts.map((acct) => {
       const bal = acct.balances as { current?: number; available?: number; iso_currency_code?: string } | undefined;
-      const base = { clerk_user_id: userId, plaid_account_id: acct.account_id, name: acct.name, type: acct.type, subtype: acct.subtype ?? null, mask: acct.mask ?? null };
-      try {
-        await db.from("accounts").upsert(
-          { ...base, balance_current: bal?.current ?? null, balance_available: bal?.available ?? null, iso_currency_code: bal?.iso_currency_code ?? "USD" },
-          { onConflict: "plaid_account_id" }
-        );
-      } catch {
-        await db.from("accounts").upsert(base, { onConflict: "plaid_account_id" });
-      }
+      return {
+        clerk_user_id: userId,
+        plaid_account_id: acct.account_id,
+        name: acct.name,
+        type: acct.type,
+        subtype: acct.subtype ?? null,
+        mask: acct.mask ?? null,
+        balance_current: bal?.current ?? null,
+        balance_available: bal?.available ?? null,
+        iso_currency_code: bal?.iso_currency_code ?? "USD",
+      };
+    });
+    if (rows.length > 0) {
+      await db.from("accounts").upsert(rows, { onConflict: "plaid_account_id" });
     }
-    const { data: updated } = await db.from("accounts").select("*").eq("clerk_user_id", userId);
+    const { data: updated } = await db.from("accounts").select("id, plaid_account_id, name, type, subtype, mask, balance_current, balance_available, iso_currency_code").eq("clerk_user_id", userId);
     const accounts: AccountRow[] = (updated ?? []).map((row: Record<string, unknown>) => ({
       account_id: String(row.plaid_account_id ?? ""),
       id: String(row.id ?? ""),

--- a/app/api/subscriptions/route.ts
+++ b/app/api/subscriptions/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
   }
   try {
     const db = getSupabase();
-    const { data, error } = await db.from("subscriptions").select("id, merchant_name, amount, frequency, last_charge_date, next_due_date, primary_category, transaction_count, status").eq("clerk_user_id", effectiveUserId).eq("status", "active").order("amount", { ascending: false });
+    const { data, error } = await db.from("subscriptions").select("id, merchant_name, amount, frequency, last_charge_date, next_due_date, primary_category, transaction_count, status").eq("clerk_user_id", effectiveUserId).eq("status", "active").order("amount", { ascending: false }).limit(200);
     if (error) throw error;
     const subs = (data ?? []).map((s) => ({ id: s.id, merchant: s.merchant_name ?? "Unknown", amount: Number(s.amount) || 0, frequency: s.frequency ?? "monthly", lastCharged: s.last_charge_date ?? null, nextDue: s.next_due_date ?? null, category: (s.primary_category ?? "SUBSCRIPTIONS").replace(/_/g, " "), transactionCount: s.transaction_count ?? 0, status: s.status ?? "active" }));
     return NextResponse.json(subs);


### PR DESCRIPTION
## Summary
Performance audit fixes:
- Batch account upsert instead of N+1 individual inserts
- Narrowed SELECT * to specific columns in accounts queries
- Added pagination limits to unbounded list queries (splits, subscriptions)

## Test plan
- [ ] All existing tests pass
- [ ] Accounts page loads correctly
- [ ] Subscriptions and groups load correctly