### PR TITLE
fix: consolidate CI into single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,7 @@ jobs:
 
       - run: npm run build
 
-  e2e:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+      - run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
         run: npx playwright test


### PR DESCRIPTION
## Summary
- Merged the separate `Build` and `E2E Tests` jobs into a single `Build` job
- PRs now show only 1 CI check instead of 2
- Same steps run (build + Playwright), just in one job

## Test plan
- [ ] Verify this PR shows a single "Build" check
- [ ] Confirm Playwright tests still run and artifacts upload on failure

Made with [Cursor](https://cursor.com)