### PR TITLE
fix: split CI into separate Build and E2E Tests jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,21 @@ jobs:
 
       - run: npm run build
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
       - run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests


### PR DESCRIPTION
## Summary
- Split CI back into 2 separate checks: **Build** and **E2E Tests**
- E2E Tests runs after Build succeeds (`needs: build`)

## Test plan
- [ ] Verify PR shows 2 separate checks (Build + E2E Tests)

Made with [Cursor](https://cursor.com)