### PR TITLE
fix: dashboard calculation bugs — spending metrics, net worth

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
   const [accountsResult, subsResult] = await Promise.all([
     db
       .from("accounts")
-      .select("type, balance_current, iso_currency_code")
+      .select("name, type, subtype, mask, balance_current, balance_available, iso_currency_code")
       .eq("clerk_user_id", effectiveUserId),
     db
       .from("subscriptions")
@@ -23,20 +23,35 @@ export async function GET() {
       .order("next_due_date", { ascending: true }),
   ]);
 
-  // Net worth: assets (depository, investment, brokerage) minus liabilities (credit, loan)
-  const accounts = accountsResult.data ?? [];
-  const assetTypes = new Set(["depository", "investment", "brokerage", "other"]);
+  // Deduplicate accounts — same name+mask can appear from sandbox + production items
+  const rawAccounts = accountsResult.data ?? [];
+  const seen = new Map<string, (typeof rawAccounts)[number]>();
+  for (const a of rawAccounts) {
+    const key = `${a.name ?? ""}|${a.mask ?? ""}`;
+    if (!seen.has(key)) seen.set(key, a);
+  }
+  const accounts = [...seen.values()];
+
+  // Net worth: assets minus liabilities
+  // Plaid stores balance_current as positive for all account types:
+  //   depository/investment: positive = money you have
+  //   credit/loan: positive = money you owe
   const liabilityTypes = new Set(["credit", "loan"]);
 
   let assets = 0;
   let liabilities = 0;
   for (const a of accounts) {
-    const bal = Number(a.balance_current) || 0;
     const type = (a.type || "").toLowerCase();
-    if (liabilityTypes.has(type)) {
+    const isLiability = liabilityTypes.has(type);
+
+    // For depository, prefer balance_available (excludes pending debits)
+    const bal =
+      !isLiability && a.balance_available != null
+        ? Number(a.balance_available)
+        : Number(a.balance_current) || 0;
+
+    if (isLiability) {
       liabilities += Math.abs(bal);
-    } else if (assetTypes.has(type)) {
-      assets += bal;
     } else {
       assets += bal;
     }

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -57,56 +57,58 @@ interface TopMerchant {
 }
 
 function deriveFromTransactions(transactions: { amount: number; date: string; category?: string; merchant?: string }[]) {
-  const byMonth: Record<string, number> = {};
-  const byCategory: Record<string, number> = {};
+  // Spending metrics use ONLY expenses (negative amounts).
+  // Plaid convention in Coconut: negative = expense, positive = income.
+  const spendByMonth: Record<string, number> = {};
+  const spendByCategory: Record<string, number> = {};
   const now = new Date();
   const thisMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
   const prevDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
   const prevMonthKey = `${prevDate.getFullYear()}-${String(prevDate.getMonth() + 1).padStart(2, "0")}`;
 
-  // Monthly income/expense breakdown
   let thisMonthIncome = 0;
   let thisMonthExpenses = 0;
 
-  // Per-category per-month for month-over-month
   const catByMonth: Record<string, Record<string, number>> = {};
-
-  // Top merchants (expenses only)
   const merchantTotals: Record<string, { total: number; count: number }> = {};
 
   for (const tx of transactions) {
-    const amt = Math.round(Math.abs(tx.amount) * 100) / 100;
+    const absAmt = Math.round(Math.abs(tx.amount) * 100) / 100;
     const month = tx.date.slice(0, 7);
-    const [y, m] = month.split("-").map(Number);
-    const monthLabel = new Date(y, m - 1).toLocaleString("en", { month: "short" });
-    byMonth[monthLabel] = Math.round(((byMonth[monthLabel] ?? 0) + amt) * 100) / 100;
+    const isExpense = tx.amount < 0;
 
-    const cat = tx.category ?? "Other";
-    byCategory[cat] = Math.round(((byCategory[cat] ?? 0) + amt) * 100) / 100;
-
-    // Income vs expenses for current month
+    // Cash flow: track income and expenses separately for current month
     if (month === thisMonthKey) {
-      if (tx.amount > 0) thisMonthIncome += amt;
-      else thisMonthExpenses += amt;
+      if (isExpense) thisMonthExpenses += absAmt;
+      else thisMonthIncome += absAmt;
     }
 
-    // Category by month
-    if (month === thisMonthKey || month === prevMonthKey) {
-      if (!catByMonth[cat]) catByMonth[cat] = {};
-      catByMonth[cat][month] = (catByMonth[cat][month] ?? 0) + amt;
-    }
+    // All spending metrics: expenses only
+    if (isExpense) {
+      // Spending by month (for chart) — key by YYYY-MM for correct chronological sorting
+      spendByMonth[month] = Math.round(((spendByMonth[month] ?? 0) + absAmt) * 100) / 100;
 
-    // Top merchants (only count expenses)
-    if (tx.amount < 0 && tx.merchant) {
-      if (!merchantTotals[tx.merchant]) merchantTotals[tx.merchant] = { total: 0, count: 0 };
-      merchantTotals[tx.merchant].total += amt;
-      merchantTotals[tx.merchant].count++;
+      const cat = tx.category ?? "Other";
+      spendByCategory[cat] = Math.round(((spendByCategory[cat] ?? 0) + absAmt) * 100) / 100;
+
+      // Category by month (for month-over-month deltas)
+      if (month === thisMonthKey || month === prevMonthKey) {
+        if (!catByMonth[cat]) catByMonth[cat] = {};
+        catByMonth[cat][month] = (catByMonth[cat][month] ?? 0) + absAmt;
+      }
+
+      // Top merchants
+      if (tx.merchant) {
+        if (!merchantTotals[tx.merchant]) merchantTotals[tx.merchant] = { total: 0, count: 0 };
+        merchantTotals[tx.merchant].total += absAmt;
+        merchantTotals[tx.merchant].count++;
+      }
     }
   }
 
   const colors = ["#3D8E62", "#4A6CF7", "#9B59B6", "#E8507A", "#F59E0B", "#CBD5E1"];
-  const total = Object.values(byCategory).reduce((a, b) => a + b, 0);
-  const categoryData = Object.entries(byCategory)
+  const total = Object.values(spendByCategory).reduce((a, b) => a + b, 0);
+  const categoryData = Object.entries(spendByCategory)
     .sort(([, a], [, b]) => b - a)
     .slice(0, 6)
     .map(([name, amount], i) => ({
@@ -116,25 +118,23 @@ function deriveFromTransactions(transactions: { amount: number; date: string; ca
       pct: total ? Math.round((amount / total) * 100) : 0,
     }));
 
-  const spendingData = Object.entries(byMonth)
-    .sort(([a], [b]) => {
-      const order = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-      return order.indexOf(a) - order.indexOf(b);
-    })
+  // Sort by YYYY-MM key (chronological), then display as short month name
+  const spendingData = Object.entries(spendByMonth)
+    .sort(([a], [b]) => a.localeCompare(b))
     .slice(-6)
-    .map(([month, amount]) => ({ month, amount }));
+    .map(([ym, amount]) => {
+      const [y, m] = ym.split("-").map(Number);
+      return { month: new Date(y, m - 1).toLocaleString("en", { month: "short" }), amount };
+    });
 
-  const thisMonth = now.toLocaleString("en", { month: "short" });
-  const monthlySpend = byMonth[thisMonth] ?? 0;
+  const monthlySpend = spendByMonth[thisMonthKey] ?? 0;
 
-  // Net cash flow
   const cashFlow: MonthStats = {
     income: thisMonthIncome,
     expenses: thisMonthExpenses,
     net: thisMonthIncome - thisMonthExpenses,
   };
 
-  // Month-over-month category deltas
   const categoryDeltas: CategoryDelta[] = Object.entries(catByMonth)
     .map(([name, months], i) => {
       const current = months[thisMonthKey] ?? 0;
@@ -147,7 +147,6 @@ function deriveFromTransactions(transactions: { amount: number; date: string; ca
     .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
     .slice(0, 5);
 
-  // Top merchants
   const topMerchants: TopMerchant[] = Object.entries(merchantTotals)
     .sort(([, a], [, b]) => b.total - a.total)
     .slice(0, 5)


### PR DESCRIPTION
## Summary

- **Spending metrics were inflated by income**: Monthly Spend, the Spending Chart, Top Categories, and Month-over-Month deltas were all using `Math.abs()` on every transaction — including paychecks and refunds. A $5,000 deposit would add $5,000 to "Monthly Spend." Now only expenses (negative amounts) feed these calculations.
- **Spending chart sorted incorrectly across year boundaries**: Months were keyed by short name ("Jan", "Feb") and sorted alphabetically against a static array, which breaks when data spans Dec → Jan. Now keyed by `YYYY-MM` and sorted with `localeCompare` for correct chronological order.
- **Net worth double-counted accounts**: Duplicate account rows (e.g. from sandbox + production Plaid items) were summed multiple times. Added deduplication by `name|mask`.
- **Net worth used suboptimal balance field**: Depository accounts now prefer `balance_available` over `balance_current`, which excludes pending debits for a more accurate picture.

Supersedes #42.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 77 unit tests pass
- [ ] Verify dashboard shows realistic Monthly Spend (should be much lower than before if user has income deposits)
- [ ] Verify Net Cash Flow breakdown (income in / expenses out) looks correct
- [ ] Verify Net Worth isn't double-counting linked accounts
- [ ] Verify spending chart months are in correct chronological order


Made with [Cursor](https://cursor.com)