### PR TITLE
fix: sort email receipts newest first

### DIFF
--- a/app/app/email-receipts/page.tsx
+++ b/app/app/email-receipts/page.tsx
@@ -170,7 +170,7 @@ function EmailReceiptsContent() {
       if (end && receiptDate > end) return false;
 
       return true;
-    });
+    }).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   }, [receipts, filter, datePreset, customStart, customEnd]);
 
   const totalAmount = filteredReceipts.reduce((sum, r) => sum + r.amount, 0);


### PR DESCRIPTION
## Summary

Receipts were displayed in arbitrary order from the API. Now sorted by date descending (newest first) in the client-side filter.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Verify receipts list shows most recent at the top


Made with [Cursor](https://cursor.com)