### PR TITLE
fix: prevent Connect Gmail flash on email receipts page

### DIFF
--- a/app/app/email-receipts/page.tsx
+++ b/app/app/email-receipts/page.tsx
@@ -177,6 +177,12 @@ function EmailReceiptsContent() {
 
   const activePresetLabel = DATE_PRESETS.find((p) => p.value === datePreset)?.label ?? "All Time";
 
+  if (gmail.loading) {
+    return (
+      <div className="min-h-screen bg-gray-50" />
+    );
+  }
+
   if (!gmail.connected) {
     return (
       <div className="min-h-screen bg-gray-50 p-4">


### PR DESCRIPTION
## Summary

When opening the Email Receipts tab, the "Connect Gmail" CTA flashed for a split second before the real content loaded. Now renders an empty page while the Gmail connection status is still loading — no spinner, no flash.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Open Email Receipts tab — should not flash "Connect Gmail" screen


Made with [Cursor](https://cursor.com)