### PR TITLE
feat: overhaul subscription detection — 3-layer strategy with 130+ known services

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -69,6 +69,7 @@ export async function GET() {
   const totalMonthly = subs.reduce((acc, s) => {
     if (s.frequency === "monthly") return acc + s.amount;
     if (s.frequency === "yearly") return acc + s.amount / 12;
+    if (s.frequency === "quarterly") return acc + s.amount / 3;
     if (s.frequency === "weekly") return acc + s.amount * 4.33;
     if (s.frequency === "biweekly") return acc + s.amount * 2.17;
     return acc + s.amount;

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -106,12 +106,14 @@ export default function SubscriptionsPage() {
                   const monthly =
                     sub.frequency === "monthly" ? sub.amount
                     : sub.frequency === "yearly" ? sub.amount / 12
+                    : sub.frequency === "quarterly" ? sub.amount / 3
                     : sub.frequency === "weekly" ? sub.amount * 4.33
                     : sub.frequency === "biweekly" ? sub.amount * 2.17
                     : sub.amount;
                   const yearly =
                     sub.frequency === "yearly" ? sub.amount
                     : sub.frequency === "monthly" ? sub.amount * 12
+                    : sub.frequency === "quarterly" ? sub.amount * 4
                     : sub.frequency === "weekly" ? sub.amount * 52
                     : sub.frequency === "biweekly" ? sub.amount * 26
                     : sub.amount * 12;

--- a/hooks/useSubscriptions.ts
+++ b/hooks/useSubscriptions.ts
@@ -91,6 +91,7 @@ export function useSubscriptions() {
   const totalMonthly = subscriptions.reduce((acc, s) => {
     if (s.frequency === "monthly") return acc + s.amount;
     if (s.frequency === "yearly") return acc + s.amount / 12;
+    if (s.frequency === "quarterly") return acc + s.amount / 3;
     if (s.frequency === "weekly") return acc + s.amount * 4.33;
     if (s.frequency === "biweekly") return acc + s.amount * 2.17;
     return acc + s.amount;

--- a/lib/known-subscriptions.ts
+++ b/lib/known-subscriptions.ts
@@ -1,0 +1,221 @@
+/**
+ * Curated database of known subscription services.
+ * Used to detect subscriptions from a single transaction —
+ * no recurring pattern needed if the merchant is in this list.
+ */
+
+export interface KnownSubscription {
+  patterns: string[];
+  name: string;
+  defaultFrequency: "weekly" | "monthly" | "yearly";
+  category: string;
+}
+
+export const KNOWN_SUBSCRIPTIONS: KnownSubscription[] = [
+  // ── Streaming Video ───────────────────────────────────────────────────────
+  { patterns: ["netflix"], name: "Netflix", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["hulu"], name: "Hulu", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["disney+", "disney plus", "disneyplus"], name: "Disney+", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["hbo max", "hbomax", "max.com"], name: "Max (HBO)", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["paramount+", "paramount plus", "paramountplus"], name: "Paramount+", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["peacock", "peacocktv"], name: "Peacock", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["apple tv", "appletv"], name: "Apple TV+", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["amazon prime video", "primevideo"], name: "Prime Video", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["crave", "cravetv"], name: "Crave", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["crunchyroll"], name: "Crunchyroll", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["funimation"], name: "Funimation", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["mubi"], name: "MUBI", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["criterion channel"], name: "Criterion Channel", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["curiositystream", "curiosity stream"], name: "CuriosityStream", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["discovery+", "discovery plus"], name: "Discovery+", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["tubi"], name: "Tubi", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["youtube premium", "youtube music", "youtube tv", "google youtube"], name: "YouTube Premium", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["twitch", "twitch.tv"], name: "Twitch", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+
+  // ── Music ─────────────────────────────────────────────────────────────────
+  { patterns: ["spotify"], name: "Spotify", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["apple music"], name: "Apple Music", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["tidal"], name: "Tidal", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["deezer"], name: "Deezer", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["soundcloud"], name: "SoundCloud", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["pandora"], name: "Pandora", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["amazon music"], name: "Amazon Music", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+
+  // ── AI / Developer Tools ──────────────────────────────────────────────────
+  { patterns: ["openai", "chatgpt", "chat gpt"], name: "ChatGPT Plus", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["anthropic", "claude.ai", "claude ai"], name: "Claude Pro", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["cursor", "cursor.sh", "cursor.com"], name: "Cursor Pro", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["github copilot", "copilot"], name: "GitHub Copilot", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["midjourney", "mid journey"], name: "Midjourney", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["replit"], name: "Replit", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["vercel"], name: "Vercel", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["netlify"], name: "Netlify", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["heroku"], name: "Heroku", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["perplexity"], name: "Perplexity Pro", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["runway", "runwayml"], name: "Runway", defaultFrequency: "monthly", category: "SOFTWARE" },
+
+  // ── Software / Productivity ───────────────────────────────────────────────
+  { patterns: ["adobe", "creative cloud"], name: "Adobe Creative Cloud", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["microsoft 365", "microsoft office", "office 365", "ms 365"], name: "Microsoft 365", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["google one", "google storage"], name: "Google One", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["google workspace"], name: "Google Workspace", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["dropbox"], name: "Dropbox", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["icloud", "apple.com/bill", "apple.com bill"], name: "iCloud+", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["notion"], name: "Notion", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["1password", "one password", "onepassword"], name: "1Password", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["lastpass"], name: "LastPass", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["bitwarden"], name: "Bitwarden", defaultFrequency: "yearly", category: "SOFTWARE" },
+  { patterns: ["dashlane"], name: "Dashlane", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["github"], name: "GitHub", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["gitlab"], name: "GitLab", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["jetbrains"], name: "JetBrains", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["figma"], name: "Figma", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["canva"], name: "Canva", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["slack"], name: "Slack", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["zoom", "zoom.us"], name: "Zoom", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["grammarly"], name: "Grammarly", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["evernote"], name: "Evernote", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["todoist"], name: "Todoist", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["linear"], name: "Linear", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["superhuman"], name: "Superhuman", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["proton", "protonmail", "proton mail"], name: "Proton", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["nordvpn", "nord vpn"], name: "NordVPN", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["expressvpn", "express vpn"], name: "ExpressVPN", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["surfshark"], name: "Surfshark", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["mullvad"], name: "Mullvad VPN", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["tailscale"], name: "Tailscale", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["cloudflare"], name: "Cloudflare", defaultFrequency: "monthly", category: "SOFTWARE" },
+
+  // ── Cloud Storage / Hosting ───────────────────────────────────────────────
+  { patterns: ["aws", "amazon web services"], name: "AWS", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["digitalocean", "digital ocean"], name: "DigitalOcean", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["linode"], name: "Linode", defaultFrequency: "monthly", category: "SOFTWARE" },
+
+  // ── Gaming ────────────────────────────────────────────────────────────────
+  { patterns: ["xbox", "game pass", "gamepass"], name: "Xbox Game Pass", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["playstation", "ps plus", "psplus", "ps+"], name: "PlayStation Plus", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["nintendo online", "nintendo switch online"], name: "Nintendo Switch Online", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["ea play", "ea sports"], name: "EA Play", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["steam"], name: "Steam", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["epic games"], name: "Epic Games", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["geforce now"], name: "GeForce Now", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["discord nitro", "discord"], name: "Discord Nitro", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+
+  // ── News / Reading / Learning ─────────────────────────────────────────────
+  { patterns: ["nytimes", "new york times", "ny times"], name: "New York Times", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["wsj", "wall street journal"], name: "Wall Street Journal", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["washington post"], name: "Washington Post", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["the athletic"], name: "The Athletic", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["substack"], name: "Substack", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["medium"], name: "Medium", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["kindle unlimited"], name: "Kindle Unlimited", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["audible"], name: "Audible", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["scribd"], name: "Scribd", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["skillshare"], name: "Skillshare", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["masterclass"], name: "MasterClass", defaultFrequency: "yearly", category: "ENTERTAINMENT" },
+  { patterns: ["coursera"], name: "Coursera", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["brilliant"], name: "Brilliant", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["duolingo"], name: "Duolingo", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+
+  // ── Fitness / Wellness ────────────────────────────────────────────────────
+  { patterns: ["peloton"], name: "Peloton", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["strava"], name: "Strava", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["headspace"], name: "Headspace", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["calm app", "calm.com"], name: "Calm", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["myfitnesspal", "my fitness pal"], name: "MyFitnessPal", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["fitbit premium", "fitbit"], name: "Fitbit Premium", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["apple fitness"], name: "Apple Fitness+", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["planet fitness"], name: "Planet Fitness", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["la fitness"], name: "LA Fitness", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["equinox"], name: "Equinox", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["orangetheory", "orange theory"], name: "Orangetheory", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["f45"], name: "F45 Training", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["crossfit"], name: "CrossFit", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["anytime fitness"], name: "Anytime Fitness", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["goodlife", "good life"], name: "GoodLife Fitness", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["ymca", "ywca"], name: "YMCA", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["barry's", "barrys bootcamp"], name: "Barry's", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["soulcycle", "soul cycle"], name: "SoulCycle", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["classpass", "class pass"], name: "ClassPass", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["noom"], name: "Noom", defaultFrequency: "monthly", category: "RECREATION" },
+  { patterns: ["whoop"], name: "WHOOP", defaultFrequency: "monthly", category: "RECREATION" },
+
+  // ── Delivery / Memberships ────────────────────────────────────────────────
+  { patterns: ["amazon prime", "amzn prime", "prime membership"], name: "Amazon Prime", defaultFrequency: "monthly", category: "SHOPPING" },
+  { patterns: ["instacart", "instacart+"], name: "Instacart+", defaultFrequency: "monthly", category: "FOOD_AND_DRINK" },
+  { patterns: ["doordash", "dashpass"], name: "DoorDash DashPass", defaultFrequency: "monthly", category: "FOOD_AND_DRINK" },
+  { patterns: ["uber one", "uber pass", "uber eats pass"], name: "Uber One", defaultFrequency: "monthly", category: "FOOD_AND_DRINK" },
+  { patterns: ["grubhub+", "grubhub plus"], name: "Grubhub+", defaultFrequency: "monthly", category: "FOOD_AND_DRINK" },
+  { patterns: ["walmart+", "walmart plus"], name: "Walmart+", defaultFrequency: "monthly", category: "SHOPPING" },
+  { patterns: ["costco membership", "costco wholesale"], name: "Costco Membership", defaultFrequency: "yearly", category: "SHOPPING" },
+  { patterns: ["sam's club"], name: "Sam's Club", defaultFrequency: "yearly", category: "SHOPPING" },
+
+  // ── Phone / Telecom ───────────────────────────────────────────────────────
+  { patterns: ["t-mobile", "tmobile"], name: "T-Mobile", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["at&t", "att wireless", "at t"], name: "AT&T", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["verizon"], name: "Verizon", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["mint mobile"], name: "Mint Mobile", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["visible"], name: "Visible", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["google fi"], name: "Google Fi", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["rogers wireless", "rogers communications"], name: "Rogers", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["bell mobility", "bell canada"], name: "Bell", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["telus"], name: "Telus", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["fido"], name: "Fido", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["koodo"], name: "Koodo", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["freedom mobile"], name: "Freedom Mobile", defaultFrequency: "monthly", category: "TELECOM" },
+
+  // ── Financial Services / Card Fees ────────────────────────────────────────
+  { patterns: ["american express", "amex", "amex fee"], name: "Amex Card Fee", defaultFrequency: "monthly", category: "FINANCIAL" },
+  { patterns: ["chase sapphire", "chase annual"], name: "Chase Card Fee", defaultFrequency: "yearly", category: "FINANCIAL" },
+  { patterns: ["citi annual", "citi card"], name: "Citi Card Fee", defaultFrequency: "yearly", category: "FINANCIAL" },
+  { patterns: ["capital one annual"], name: "Capital One Fee", defaultFrequency: "yearly", category: "FINANCIAL" },
+  { patterns: ["ynab", "you need a budget"], name: "YNAB", defaultFrequency: "yearly", category: "FINANCIAL" },
+  { patterns: ["copilot money"], name: "Copilot Money", defaultFrequency: "monthly", category: "FINANCIAL" },
+  { patterns: ["rocket money", "truebill"], name: "Rocket Money", defaultFrequency: "monthly", category: "FINANCIAL" },
+  { patterns: ["wealthsimple"], name: "Wealthsimple", defaultFrequency: "monthly", category: "FINANCIAL" },
+
+  // ── Dating ────────────────────────────────────────────────────────────────
+  { patterns: ["tinder"], name: "Tinder", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["bumble"], name: "Bumble", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["hinge"], name: "Hinge", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+
+  // ── Internet / Home ───────────────────────────────────────────────────────
+  { patterns: ["starlink"], name: "Starlink", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["comcast", "xfinity"], name: "Xfinity", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["spectrum"], name: "Spectrum", defaultFrequency: "monthly", category: "TELECOM" },
+  { patterns: ["cox communications"], name: "Cox", defaultFrequency: "monthly", category: "TELECOM" },
+
+  // ── Miscellaneous ─────────────────────────────────────────────────────────
+  { patterns: ["patreon"], name: "Patreon", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["onlyfans"], name: "OnlyFans", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["buy me a coffee", "buymeacoffee"], name: "Buy Me a Coffee", defaultFrequency: "monthly", category: "ENTERTAINMENT" },
+  { patterns: ["google play", "google store"], name: "Google Play", defaultFrequency: "monthly", category: "SOFTWARE" },
+  { patterns: ["apple app store", "apple store"], name: "Apple App Store", defaultFrequency: "monthly", category: "SOFTWARE" },
+];
+
+/**
+ * Build a lookup index for fast matching.
+ * Returns a function that checks if a normalized merchant name matches any known subscription.
+ */
+function buildMatcher(): (normalizedMerchant: string) => KnownSubscription | null {
+  const entries = KNOWN_SUBSCRIPTIONS.flatMap((sub) =>
+    sub.patterns.map((p) => ({ pattern: p.toLowerCase(), sub }))
+  );
+  // Sort longest patterns first to prefer more specific matches
+  entries.sort((a, b) => b.pattern.length - a.pattern.length);
+
+  return (normalizedMerchant: string): KnownSubscription | null => {
+    const lower = normalizedMerchant.toLowerCase();
+    for (const { pattern, sub } of entries) {
+      if (lower.includes(pattern)) return sub;
+    }
+    return null;
+  };
+}
+
+let _matcher: ReturnType<typeof buildMatcher> | null = null;
+
+export function matchKnownSubscription(normalizedMerchant: string): KnownSubscription | null {
+  if (!_matcher) _matcher = buildMatcher();
+  return _matcher(normalizedMerchant);
+}

--- a/lib/subscription-detect.ts
+++ b/lib/subscription-detect.ts
@@ -1,10 +1,15 @@
 /**
- * Subscription detection — find recurring charges from transaction history.
- * Excludes bills (rent, utilities, transfers, etc.) per docs/SUBSCRIPTIONS_PLAN.md.
+ * Subscription detection — three-layer strategy:
+ *   1. Known merchant database (single transaction is enough)
+ *   2. Transaction pattern analysis (recurring charges)
+ *   3. Email receipt cross-referencing
+ *
+ * Results are merged and deduplicated by normalized merchant.
  */
 
 import { getSupabase } from "./supabase";
 import { shouldExcludeAsSubscription } from "./subscription-config";
+import { matchKnownSubscription } from "./known-subscriptions";
 
 export async function deleteExcludedSubscriptions(clerkUserId: string): Promise<number> {
   const db = getSupabase();
@@ -23,7 +28,7 @@ export async function deleteExcludedSubscriptions(clerkUserId: string): Promise<
   return ids.length;
 }
 
-export type SubscriptionFrequency = "weekly" | "biweekly" | "monthly" | "yearly";
+export type SubscriptionFrequency = "weekly" | "biweekly" | "monthly" | "quarterly" | "yearly";
 
 export interface DetectedSubscription {
   merchantName: string;
@@ -36,6 +41,7 @@ export interface DetectedSubscription {
   transactionCount: number;
   transactionIds: string[];
   transactionDetails: Array<{ id: string; amount: number; date: string }>;
+  source: "known" | "pattern" | "email";
 }
 
 interface TxRow {
@@ -48,16 +54,31 @@ interface TxRow {
   primary_category: string | null;
 }
 
-const AMOUNT_TOLERANCE = 0.15;
+// ── Tuning constants ──────────────────────────────────────────────────────────
+
+const AMOUNT_TOLERANCE = 0.20;
 const MIN_OCCURRENCES = 2;
-const DAYS_MONTHLY_MIN = 25;
-const DAYS_MONTHLY_MAX = 35;
-const DAYS_YEARLY_MIN = 350;
-const DAYS_YEARLY_MAX = 380;
-const DAYS_WEEKLY_MIN = 6;
-const DAYS_WEEKLY_MAX = 9;
-const DAYS_BIWEEKLY_MIN = 12;
-const DAYS_BIWEEKLY_MAX = 16;
+const DAYS_WEEKLY = { min: 5, max: 10 };
+const DAYS_BIWEEKLY = { min: 11, max: 18 };
+const DAYS_MONTHLY = { min: 22, max: 38 };
+const DAYS_QUARTERLY = { min: 80, max: 100 };
+const DAYS_YEARLY = { min: 340, max: 395 };
+
+const MERCHANT_STRIP_SUFFIXES = [
+  "inc", "llc", "ltd", "co", "corp", "corporation", "limited",
+  "subscription", "membership", "recurring", "autopay", "auto pay",
+  "monthly", "annual", "yearly", "payment", "billing",
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function normalizeMerchantName(raw: string): string {
+  let s = raw.toLowerCase().replace(/[^a-z0-9 ]/g, " ").replace(/\s+/g, " ").trim();
+  for (const suffix of MERCHANT_STRIP_SUFFIXES) {
+    s = s.replace(new RegExp(`\\b${suffix}\\b`, "g"), "").trim();
+  }
+  return s.replace(/\s+/g, " ").trim();
+}
 
 function amountsMatch(a: number, b: number): boolean {
   const absA = Math.abs(a);
@@ -71,10 +92,11 @@ function daysBetween(d1: string, d2: string): number {
 
 function inferFrequency(dayDiffs: number[]): SubscriptionFrequency | null {
   const avg = dayDiffs.reduce((s, d) => s + d, 0) / dayDiffs.length;
-  if (avg >= DAYS_WEEKLY_MIN && avg <= DAYS_WEEKLY_MAX) return "weekly";
-  if (avg >= DAYS_BIWEEKLY_MIN && avg <= DAYS_BIWEEKLY_MAX) return "biweekly";
-  if (avg >= DAYS_MONTHLY_MIN && avg <= DAYS_MONTHLY_MAX) return "monthly";
-  if (avg >= DAYS_YEARLY_MIN && avg <= DAYS_YEARLY_MAX) return "yearly";
+  if (avg >= DAYS_WEEKLY.min && avg <= DAYS_WEEKLY.max) return "weekly";
+  if (avg >= DAYS_BIWEEKLY.min && avg <= DAYS_BIWEEKLY.max) return "biweekly";
+  if (avg >= DAYS_MONTHLY.min && avg <= DAYS_MONTHLY.max) return "monthly";
+  if (avg >= DAYS_QUARTERLY.min && avg <= DAYS_QUARTERLY.max) return "quarterly";
+  if (avg >= DAYS_YEARLY.min && avg <= DAYS_YEARLY.max) return "yearly";
   return null;
 }
 
@@ -84,25 +106,94 @@ function addDays(dateStr: string, days: number): string {
   return d.toISOString().slice(0, 10);
 }
 
-export async function detectSubscriptionsForUser(clerkUserId: string): Promise<DetectedSubscription[]> {
-  const db = getSupabase();
-  const { data: rows, error } = await db
-    .from("transactions")
-    .select("id, merchant_name, raw_name, normalized_merchant, amount, date, primary_category")
-    .eq("clerk_user_id", clerkUserId)
-    .lt("amount", 0)
-    .order("date", { ascending: false })
-    .order("id", { ascending: false });
+function frequencyToDays(freq: SubscriptionFrequency): number {
+  switch (freq) {
+    case "weekly": return 7;
+    case "biweekly": return 14;
+    case "monthly": return 30;
+    case "quarterly": return 90;
+    case "yearly": return 365;
+  }
+}
 
-  if (error || !rows || rows.length < MIN_OCCURRENCES) return [];
+// ── Strategy 1: Known Merchant Match ──────────────────────────────────────────
 
-  const txs = rows as TxRow[];
+function detectFromKnownMerchants(
+  txs: TxRow[],
+  alreadyFound: Set<string>,
+): DetectedSubscription[] {
+  const results: DetectedSubscription[] = [];
+  const seenKnown = new Set<string>();
+
+  for (const tx of txs) {
+    const raw = tx.merchant_name || tx.raw_name || tx.normalized_merchant || "";
+    const normalized = normalizeMerchantName(raw);
+    if (!normalized || normalized.length < 2) continue;
+
+    const known = matchKnownSubscription(raw) ?? matchKnownSubscription(normalized);
+    if (!known) continue;
+
+    const knownKey = known.name.toLowerCase();
+    if (seenKnown.has(knownKey) || alreadyFound.has(normalized)) continue;
+    seenKnown.add(knownKey);
+
+    if (shouldExcludeAsSubscription(tx.primary_category, raw, tx.raw_name || "")) continue;
+
+    const allMatchingTxs = txs.filter((t) => {
+      const tRaw = t.merchant_name || t.raw_name || t.normalized_merchant || "";
+      const tKnown = matchKnownSubscription(tRaw) ?? matchKnownSubscription(normalizeMerchantName(tRaw));
+      return tKnown?.name === known.name;
+    });
+
+    allMatchingTxs.sort((a, b) => b.date.localeCompare(a.date));
+    const latest = allMatchingTxs[0];
+    const avgAmount = allMatchingTxs.reduce((s, t) => s + Math.abs(t.amount), 0) / allMatchingTxs.length;
+
+    let frequency: SubscriptionFrequency = known.defaultFrequency;
+    if (allMatchingTxs.length >= 2) {
+      const dayDiffs: number[] = [];
+      for (let i = 0; i < allMatchingTxs.length - 1; i++) {
+        dayDiffs.push(daysBetween(allMatchingTxs[i].date, allMatchingTxs[i + 1].date));
+      }
+      const inferred = inferFrequency(dayDiffs);
+      if (inferred) frequency = inferred;
+    }
+
+    const nextDue = addDays(latest.date, frequencyToDays(frequency));
+
+    results.push({
+      merchantName: known.name,
+      normalizedMerchant: normalized,
+      amount: Math.abs(avgAmount),
+      frequency,
+      lastChargeDate: latest.date,
+      nextDueDate: nextDue,
+      primaryCategory: known.category,
+      transactionCount: allMatchingTxs.length,
+      transactionIds: allMatchingTxs.map((t) => t.id),
+      transactionDetails: allMatchingTxs.map((t) => ({ id: t.id, amount: Math.abs(t.amount), date: t.date })),
+      source: "known",
+    });
+
+    alreadyFound.add(normalized);
+  }
+
+  return results;
+}
+
+// ── Strategy 2: Transaction Pattern Analysis ──────────────────────────────────
+
+function detectFromPatterns(
+  txs: TxRow[],
+  alreadyFound: Set<string>,
+): DetectedSubscription[] {
   const byMerchant = new Map<string, TxRow[]>();
 
   for (const tx of txs) {
-    const raw = (tx.normalized_merchant || tx.merchant_name || tx.raw_name || "").trim();
-    const key = raw.toLowerCase().replace(/[^a-z0-9 ]/g, " ").replace(/\s+/g, " ").trim();
+    const raw = tx.normalized_merchant || tx.merchant_name || tx.raw_name || "";
+    const key = normalizeMerchantName(raw);
     if (!key || key.length < 3) continue;
+    if (alreadyFound.has(key)) continue;
     const list = byMerchant.get(key) ?? [];
     list.push(tx);
     byMerchant.set(key, list);
@@ -110,7 +201,7 @@ export async function detectSubscriptionsForUser(clerkUserId: string): Promise<D
 
   const results: DetectedSubscription[] = [];
 
-  for (const [, list] of byMerchant) {
+  for (const [key, list] of byMerchant) {
     if (list.length < MIN_OCCURRENCES) continue;
     list.sort((a, b) => b.date.localeCompare(a.date));
 
@@ -132,12 +223,10 @@ export async function detectSubscriptionsForUser(clerkUserId: string): Promise<D
 
     const avgDays = dayDiffs.reduce((s, d) => s + d, 0) / dayDiffs.length;
     const nextDue = addDays(lastTx.date, Math.round(avgDays));
-    const normalized =
-      (lastTx.normalized_merchant || merchant.toLowerCase().replace(/[^a-z0-9 ]/g, " ").replace(/\s+/g, " ").trim()) as string;
 
     results.push({
       merchantName: merchant,
-      normalizedMerchant: normalized,
+      normalizedMerchant: key,
       amount: Math.abs(avgAmount),
       frequency,
       lastChargeDate: lastTx.date,
@@ -146,11 +235,134 @@ export async function detectSubscriptionsForUser(clerkUserId: string): Promise<D
       transactionCount: list.length,
       transactionIds: list.map((t) => t.id),
       transactionDetails: list.map((t) => ({ id: t.id, amount: Math.abs(t.amount), date: t.date })),
+      source: "pattern",
     });
+
+    alreadyFound.add(key);
   }
 
   return results;
 }
+
+// ── Strategy 3: Email Receipt Cross-Reference ─────────────────────────────────
+
+interface EmailReceiptRow {
+  merchant: string;
+  amount: number;
+  date: string;
+}
+
+async function detectFromEmailReceipts(
+  clerkUserId: string,
+  txs: TxRow[],
+  alreadyFound: Set<string>,
+): Promise<DetectedSubscription[]> {
+  const db = getSupabase();
+  const { data: receipts } = await db
+    .from("email_receipts")
+    .select("merchant, amount, date")
+    .eq("clerk_user_id", clerkUserId)
+    .order("date", { ascending: false });
+
+  if (!receipts || receipts.length < 2) return [];
+
+  const byMerchant = new Map<string, EmailReceiptRow[]>();
+  for (const r of receipts as EmailReceiptRow[]) {
+    const key = normalizeMerchantName(r.merchant || "");
+    if (!key || key.length < 2) continue;
+    if (alreadyFound.has(key)) continue;
+    const list = byMerchant.get(key) ?? [];
+    list.push(r);
+    byMerchant.set(key, list);
+  }
+
+  const results: DetectedSubscription[] = [];
+
+  for (const [key, list] of byMerchant) {
+    if (list.length < MIN_OCCURRENCES) continue;
+    list.sort((a, b) => b.date.localeCompare(a.date));
+
+    const amounts = list.map((r) => Math.abs(r.amount));
+    const avgAmount = amounts.reduce((s, v) => s + v, 0) / amounts.length;
+    if (!amounts.every((v) => amountsMatch(v, avgAmount))) continue;
+
+    const dayDiffs: number[] = [];
+    for (let i = 0; i < list.length - 1; i++) {
+      dayDiffs.push(daysBetween(list[i].date, list[i + 1].date));
+    }
+    const frequency = inferFrequency(dayDiffs);
+    if (!frequency) continue;
+
+    // Find matching transactions for these email receipts
+    const matchingTxs = txs.filter((tx) => {
+      const txKey = normalizeMerchantName(tx.merchant_name || tx.raw_name || tx.normalized_merchant || "");
+      return txKey === key || txKey.includes(key) || key.includes(txKey);
+    });
+
+    const latest = list[0];
+    const avgDays = dayDiffs.reduce((s, d) => s + d, 0) / dayDiffs.length;
+    const nextDue = addDays(latest.date, Math.round(avgDays));
+
+    results.push({
+      merchantName: latest.merchant,
+      normalizedMerchant: key,
+      amount: Math.abs(avgAmount),
+      frequency,
+      lastChargeDate: latest.date,
+      nextDueDate: nextDue,
+      primaryCategory: "SUBSCRIPTIONS",
+      transactionCount: Math.max(list.length, matchingTxs.length),
+      transactionIds: matchingTxs.map((t) => t.id),
+      transactionDetails: matchingTxs.map((t) => ({ id: t.id, amount: Math.abs(t.amount), date: t.date })),
+      source: "email",
+    });
+
+    alreadyFound.add(key);
+  }
+
+  return results;
+}
+
+// ── Main detection entrypoint ─────────────────────────────────────────────────
+
+export async function detectSubscriptionsForUser(clerkUserId: string): Promise<DetectedSubscription[]> {
+  const db = getSupabase();
+  const { data: rows, error } = await db
+    .from("transactions")
+    .select("id, merchant_name, raw_name, normalized_merchant, amount, date, primary_category")
+    .eq("clerk_user_id", clerkUserId)
+    .lt("amount", 0)
+    .order("date", { ascending: false })
+    .order("id", { ascending: false });
+
+  if (error) {
+    console.error("[subscription-detect] Failed to load transactions:", error.message);
+    return [];
+  }
+
+  const txs = (rows ?? []) as TxRow[];
+  const alreadyFound = new Set<string>();
+
+  // Layer 1: Known merchants (highest priority — needs only 1 transaction)
+  const fromKnown = detectFromKnownMerchants(txs, alreadyFound);
+
+  // Layer 2: Transaction patterns (needs 2+ recurring charges)
+  const fromPatterns = detectFromPatterns(txs, alreadyFound);
+
+  // Layer 3: Email receipt patterns (needs 2+ email receipts from same merchant)
+  const fromEmail = await detectFromEmailReceipts(clerkUserId, txs, alreadyFound);
+
+  const all = [...fromKnown, ...fromPatterns, ...fromEmail];
+
+  console.log(
+    `[subscription-detect] Detected ${all.length} subscriptions:`,
+    `${fromKnown.length} known, ${fromPatterns.length} pattern, ${fromEmail.length} email`
+  );
+
+  return all;
+}
+
+// ── Save to database ──────────────────────────────────────────────────────────
 
 export async function saveDetectedSubscriptions(clerkUserId: string, detected: DetectedSubscription[]): Promise<void> {
   const db = getSupabase();
@@ -186,23 +398,25 @@ export async function saveDetectedSubscriptions(clerkUserId: string, detected: D
 
     if (error) continue;
 
-    const { data: sub } = await db
-      .from("subscriptions")
-      .select("id")
-      .eq("clerk_user_id", clerkUserId)
-      .eq("normalized_merchant", d.normalizedMerchant)
-      .single();
+    if (d.transactionDetails.length > 0) {
+      const { data: sub } = await db
+        .from("subscriptions")
+        .select("id")
+        .eq("clerk_user_id", clerkUserId)
+        .eq("normalized_merchant", d.normalizedMerchant)
+        .single();
 
-    if (sub && d.transactionDetails.length > 0) {
-      try {
-        for (const td of d.transactionDetails.slice(0, 10)) {
-          await db.from("subscription_transactions").upsert(
-            { subscription_id: sub.id, transaction_id: td.id, amount: td.amount, date: td.date },
-            { onConflict: "subscription_id,transaction_id" }
-          );
+      if (sub) {
+        try {
+          for (const td of d.transactionDetails.slice(0, 10)) {
+            await db.from("subscription_transactions").upsert(
+              { subscription_id: sub.id, transaction_id: td.id, amount: td.amount, date: td.date },
+              { onConflict: "subscription_id,transaction_id" }
+            );
+          }
+        } catch {
+          // best-effort
         }
-      } catch {
-        // optional
       }
     }
   }


### PR DESCRIPTION
## Summary

Complete overhaul of the "Detect subscriptions" feature using three complementary detection strategies:

### Layer 1: Known Merchant Database (new)
- **130+ curated subscription services** targeting tech-savvy / young adult users
- Covers: streaming (Netflix, Disney+, Hulu, Crave, Crunchyroll), AI tools (ChatGPT, Claude, Cursor, Copilot, Midjourney, Perplexity), music (Spotify, Apple Music, Tidal), software (Adobe, Notion, 1Password, Figma, Canva, Grammarly), fitness (Planet Fitness, Equinox, ClassPass, Peloton, WHOOP), delivery (Instacart+, DoorDash DashPass, Amazon Prime, Uber One), telecom (T-Mobile, Verizon, Rogers, Bell, Fido, Koodo), financial (Amex card fees, YNAB, Copilot Money), gaming (Xbox Game Pass, PS Plus, Discord Nitro), news (NYT, WSJ, Substack), VPNs (NordVPN, Mullvad), dating (Tinder, Bumble, Hinge), and more
- **Only needs 1 transaction** to detect — no recurring pattern required

### Layer 2: Transaction Pattern Analysis (tuned)
- Widened monthly window: 22-38 days (was 25-35)
- Widened yearly window: 340-395 days (was 350-380)
- Increased amount tolerance: 20% (was 15%)
- **Added quarterly frequency**: 80-100 day gaps
- Smarter merchant normalization: strips "inc", "llc", "subscription", "membership", "recurring", etc.

### Layer 3: Email Receipt Cross-Referencing (new)
- Scans `email_receipts` for recurring merchants
- If same merchant appears 2+ times at regular intervals in email receipts, flags as subscription
- Cross-references with bank transactions for linking

### Merge
All three strategies deduplicate by normalized merchant. Known merchants take priority, then patterns, then email.

## Files changed
- **New**: `lib/known-subscriptions.ts` — curated database + fast matcher
- **Rewritten**: `lib/subscription-detect.ts` — three-strategy engine
- **Updated**: `app/api/dashboard/route.ts`, `hooks/useSubscriptions.ts`, `app/app/subscriptions/page.tsx` — added quarterly frequency support

## Test plan
- [x] `npm run typecheck` passes
- [x] All 77 unit tests pass
- [ ] Click "Detect subscriptions" — should find services from your transaction history
- [ ] Verify Spotify, ChatGPT, Cursor, Instacart+, Amazon Prime, Amex fee, Google Cloud are detected
- [ ] Verify quarterly subscriptions display correctly in monthly/annual totals


Made with [Cursor](https://cursor.com)