### PR TITLE
fix: telegram bot fails on coconut-app bugs (missing label)

### DIFF
--- a/app/api/telegram-webhook/route.ts
+++ b/app/api/telegram-webhook/route.ts
@@ -439,6 +439,32 @@ async function createGitHubIssue(repo: RepoKey, opts: {
     }
   );
 
+  // If labels cause a permission error, retry without them
+  if (!res.ok && opts.labels.length > 0) {
+    const errText = await res.text();
+    if (res.status === 403 || res.status === 422) {
+      console.warn(`Label issue on ${repo}, retrying without labels: ${errText}`);
+      const { labels: _labels, ...withoutLabels } = opts;
+      const retry = await fetch(
+        `https://api.github.com/repos/${REPOS[repo]}/issues`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${GITHUB_TOKEN}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(withoutLabels),
+        }
+      );
+      if (!retry.ok) {
+        throw new Error(`GitHub issue creation failed: ${retry.status} ${await retry.text()}`);
+      }
+      const data = await retry.json();
+      return data.html_url;
+    }
+    throw new Error(`GitHub issue creation failed: ${res.status} ${errText}`);
+  }
+
   if (!res.ok) {
     throw new Error(`GitHub issue creation failed: ${res.status} ${await res.text()}`);
   }


### PR DESCRIPTION
## Summary
- **Root cause found**: The GitHub bot token gets a 403 when filing Mobile App bugs because the `ai-fix` label doesn't exist on `Coconut-Banking/coconut-app` and the token can't create labels
- Added fallback: if issue creation fails due to labels (403/422), retry without labels so the issue still gets created
- Web App (coconut) bugs work fine — only Mobile App was broken

## Root cause
```
GitHub issue creation failed: 403 "You do not have permission to create labels on this repository."
```
Verified by sending test webhook payloads to the live deployment.

## Test plan
- [x] Web App bug filing works (tested via curl → created issue successfully)
- [x] Mobile App bug filing now retries without labels on 403
- [ ] After merge + deploy, test full flow: /start → File a Bug → Mobile App → send description → verify issue created

## Also needed (manual)
Create the `ai-fix` label on `Coconut-Banking/coconut-app` so the AI Fix runner can find issues. Until then, issues will be created without the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)