### PR TITLE
feat: remaining improvements — encryption, P2P handles, receipt matching, item analytics

### DIFF
--- a/app/api/email-receipts/[id]/match/route.ts
+++ b/app/api/email-receipts/[id]/match/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getSupabase } from "@/lib/supabase";
+
+/** POST — manually match a receipt to a transaction */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { transactionId } = body;
+  if (!transactionId || typeof transactionId !== "string") {
+    return NextResponse.json({ error: "transactionId is required" }, { status: 400 });
+  }
+
+  const db = getSupabase();
+
+  // Verify receipt ownership
+  const { data: receipt, error: receiptError } = await db
+    .from("email_receipts")
+    .select("id")
+    .eq("id", id)
+    .eq("clerk_user_id", userId)
+    .single();
+
+  if (receiptError || !receipt) {
+    return NextResponse.json({ error: "Receipt not found" }, { status: 404 });
+  }
+
+  // Verify transaction ownership
+  const { data: transaction, error: txError } = await db
+    .from("transactions")
+    .select("id")
+    .eq("id", transactionId)
+    .eq("clerk_user_id", userId)
+    .single();
+
+  if (txError || !transaction) {
+    return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+  }
+
+  // Update receipt with the matched transaction
+  const { error: updateError } = await db
+    .from("email_receipts")
+    .update({ transaction_id: transactionId })
+    .eq("id", id)
+    .eq("clerk_user_id", userId);
+
+  if (updateError) {
+    console.error("Failed to match receipt:", updateError);
+    return NextResponse.json({ error: "Failed to match receipt" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+/** DELETE — unmatch a receipt from its transaction */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const db = getSupabase();
+
+  // Verify receipt ownership
+  const { data: receipt, error: receiptError } = await db
+    .from("email_receipts")
+    .select("id")
+    .eq("id", id)
+    .eq("clerk_user_id", userId)
+    .single();
+
+  if (receiptError || !receipt) {
+    return NextResponse.json({ error: "Receipt not found" }, { status: 404 });
+  }
+
+  // Clear the match
+  const { error: updateError } = await db
+    .from("email_receipts")
+    .update({ transaction_id: null })
+    .eq("id", id)
+    .eq("clerk_user_id", userId);
+
+  if (updateError) {
+    console.error("Failed to unmatch receipt:", updateError);
+    return NextResponse.json({ error: "Failed to unmatch receipt" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -24,7 +24,7 @@ export async function GET(
 
   let { data: members } = await db
     .from("group_members")
-    .select("id, user_id, email, display_name")
+    .select("id, user_id, email, display_name, venmo_username, cashapp_cashtag, paypal_username")
     .eq("group_id", id);
 
   // Backfill owner email for existing groups where owner has user_id but no email

--- a/app/api/insights/items/route.ts
+++ b/app/api/insights/items/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getEffectiveUserId } from "@/lib/demo";
+import { detectItemTrends } from "@/lib/item-insights";
+import { rateLimit } from "@/lib/rate-limit";
+
+export async function GET() {
+  const userId = await getEffectiveUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const rl = rateLimit(`item-insights:${userId}`, 10, 60_000);
+  if (!rl.success) return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+
+  try {
+    const insights = await detectItemTrends(userId);
+    return NextResponse.json({ insights });
+  } catch (e) {
+    console.error("[item-insights]", e);
+    const message = e instanceof Error ? e.message : "Failed to generate item insights";
+    return NextResponse.json(
+      { error: message, insights: [] },
+      { status: 500 }
+    );
+  }
+}

--- a/app/app/dashboard/page.tsx
+++ b/app/app/dashboard/page.tsx
@@ -190,6 +190,7 @@ export default function DashboardPage() {
   const { currencyCode, format: fc } = useCurrency();
   const { manualMonthlyIncome } = useManualMonthlyIncome();
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [itemInsights, setItemInsights] = useState<Array<{ type: string; message: string; detail?: string }>>([]);
 
   useEffect(() => {
     if (!linked) return;
@@ -236,6 +237,19 @@ export default function DashboardPage() {
         }
       })
       .catch(() => {});
+  }, [linked]);
+
+  // Item-level insights from receipt line items
+  useEffect(() => {
+    if (!linked) return;
+    const controller = new AbortController();
+    fetch("/api/insights/items", { signal: controller.signal })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (data?.insights) setItemInsights(data.insights); })
+      .catch((e) => {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+      });
+    return () => controller.abort();
   }, [linked]);
 
   if (loading) {
@@ -641,9 +655,17 @@ export default function DashboardPage() {
                   You owe <span className="text-red-500 font-medium">{fc(groupsSummary.totalIOwe)}</span> across groups
                 </p>
               )}
-              {(!linked || (categoryDeltas.length === 0 && !groupsSummary?.friends?.some((f) => f.balance > 0) && (groupsSummary?.totalIOwe ?? 0) <= 0)) && (
+              {(!linked || (categoryDeltas.length === 0 && !groupsSummary?.friends?.some((f) => f.balance > 0) && (groupsSummary?.totalIOwe ?? 0) <= 0 && itemInsights.length === 0)) && (
                 <p className="text-sm text-gray-500">Connect accounts and sync to see insights.</p>
               )}
+              {itemInsights.map((insight, i) => (
+                <p key={`item-${i}`} className="text-sm text-gray-700">
+                  {insight.message}
+                  {insight.detail && (
+                    <span className="text-gray-400 ml-1 text-xs">({insight.detail})</span>
+                  )}
+                </p>
+              ))}
             </div>
           </div>
 

--- a/app/app/email-receipts/page.tsx
+++ b/app/app/email-receipts/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect, useMemo, Suspense } from "react";
+import { useState, useEffect, useMemo, useCallback, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { Loader2, Mail, Package, Calendar, ChevronRight, RefreshCw, AlertCircle, CheckCircle2, Search, ChevronDown, X, ExternalLink } from "lucide-react";
+import { Loader2, Mail, Package, Calendar, ChevronRight, RefreshCw, AlertCircle, CheckCircle2, Search, ChevronDown, X, ExternalLink, Link2, Unlink, ArrowRight } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import { motion } from "motion/react";
 import { useGmail } from "@/hooks/useGmail";
@@ -28,6 +28,16 @@ interface Receipt {
   transaction_id?: string;
 }
 
+interface TransactionCandidate {
+  dbId: string;
+  merchant: string;
+  amount: number;
+  date: string;
+  dateStr: string;
+  isoCurrencyCode: string;
+}
+
+type ReviewTab = "unmatched" | "matched";
 type DatePreset = "30d" | "3m" | "6m" | "1y" | "all" | "custom";
 
 const DATE_PRESETS: { value: DatePreset; label: string }[] = [
@@ -80,6 +90,97 @@ function EmailReceiptsContent() {
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
   const [showPresetMenu, setShowPresetMenu] = useState(false);
+  const [reviewTab, setReviewTab] = useState<ReviewTab>("unmatched");
+  const [showReview, setShowReview] = useState(false);
+  const [findingMatchFor, setFindingMatchFor] = useState<string | null>(null);
+  const [candidates, setCandidates] = useState<TransactionCandidate[]>([]);
+  const [loadingCandidates, setLoadingCandidates] = useState(false);
+  const [matchingReceipt, setMatchingReceipt] = useState<string | null>(null);
+
+  const findCandidates = useCallback(async (receipt: Receipt) => {
+    setFindingMatchFor(receipt.id);
+    setCandidates([]);
+    setLoadingCandidates(true);
+    try {
+      const res = await fetch("/api/plaid/transactions");
+      if (!res.ok) return;
+      const transactions: TransactionCandidate[] = await res.json();
+      const receiptAmount = Math.abs(receipt.amount);
+      const receiptDate = new Date(receipt.date + "T12:00:00").getTime();
+      const sevenDays = 7 * 24 * 60 * 60 * 1000;
+
+      const scored = transactions
+        .filter((tx) => {
+          const txAmount = Math.abs(tx.amount);
+          const amountDiff = Math.abs(txAmount - receiptAmount);
+          const withinAmount = receiptAmount > 0
+            ? amountDiff / receiptAmount <= 0.10
+            : amountDiff <= 5;
+          const txDate = new Date(tx.date + "T12:00:00").getTime();
+          const withinDate = Math.abs(txDate - receiptDate) <= sevenDays;
+          return withinAmount && withinDate;
+        })
+        .map((tx) => ({
+          ...tx,
+          _amountDiff: Math.abs(Math.abs(tx.amount) - receiptAmount),
+          _dateDiff: Math.abs(
+            new Date(tx.date + "T12:00:00").getTime() - receiptDate
+          ),
+        }))
+        .sort((a, b) => a._amountDiff - b._amountDiff || a._dateDiff - b._dateDiff)
+        .slice(0, 5);
+
+      setCandidates(scored);
+    } catch (err) {
+      console.error("Failed to find candidates:", err);
+    } finally {
+      setLoadingCandidates(false);
+    }
+  }, []);
+
+  const matchReceipt = useCallback(async (receiptId: string, transactionId: string) => {
+    setMatchingReceipt(receiptId);
+    try {
+      const res = await fetch(`/api/email-receipts/${receiptId}/match`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transactionId }),
+      });
+      if (res.ok) {
+        setReceipts((prev) =>
+          prev.map((r) =>
+            r.id === receiptId ? { ...r, transaction_id: transactionId } : r
+          )
+        );
+        setFindingMatchFor(null);
+        setCandidates([]);
+      }
+    } catch (err) {
+      console.error("Failed to match receipt:", err);
+    } finally {
+      setMatchingReceipt(null);
+    }
+  }, []);
+
+  const unmatchReceipt = useCallback(async (receiptId: string) => {
+    setMatchingReceipt(receiptId);
+    try {
+      const res = await fetch(`/api/email-receipts/${receiptId}/match`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setReceipts((prev) =>
+          prev.map((r) =>
+            r.id === receiptId ? { ...r, transaction_id: undefined } : r
+          )
+        );
+      }
+    } catch (err) {
+      console.error("Failed to unmatch receipt:", err);
+    } finally {
+      setMatchingReceipt(null);
+    }
+  }, []);
 
   useEffect(() => {
     const connected = searchParams.get("connected");
@@ -176,6 +277,15 @@ function EmailReceiptsContent() {
       return true;
     }).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   }, [receipts, filter, datePreset, customStart, customEnd]);
+
+  const unmatchedReceipts = useMemo(
+    () => filteredReceipts.filter((r) => !r.transaction_id),
+    [filteredReceipts]
+  );
+  const matchedReceipts = useMemo(
+    () => filteredReceipts.filter((r) => !!r.transaction_id),
+    [filteredReceipts]
+  );
 
   const totalAmount = filteredReceipts.reduce((sum, r) => {
     const amt = r.currency && r.currency !== currencyCode ? convertCurrency(r.amount, r.currency, currencyCode) : r.amount;
@@ -432,6 +542,225 @@ function EmailReceiptsContent() {
           </div>
         </div>
 
+        {/* Review Matches Section */}
+        <div className="mb-6">
+          <button
+            onClick={() => setShowReview((v) => !v)}
+            className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-xl text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            <Link2 className="w-4 h-4 text-[#3D8E62]" />
+            Review Matches
+            {unmatchedReceipts.length > 0 && (
+              <span className="px-1.5 py-0.5 bg-amber-100 text-amber-700 text-xs rounded-full font-medium">
+                {unmatchedReceipts.length} unmatched
+              </span>
+            )}
+            <ChevronDown className={`w-3.5 h-3.5 text-gray-400 transition-transform ${showReview ? "rotate-180" : ""}`} />
+          </button>
+
+          <AnimatePresence>
+            {showReview && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ duration: 0.2 }}
+                className="overflow-hidden"
+              >
+                <div className="mt-3 bg-white rounded-xl border border-gray-100 overflow-hidden">
+                  {/* Tabs */}
+                  <div className="flex border-b border-gray-100">
+                    <button
+                      onClick={() => setReviewTab("unmatched")}
+                      className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+                        reviewTab === "unmatched"
+                          ? "text-[#3D8E62] border-b-2 border-[#3D8E62] bg-[#EEF7F2]/30"
+                          : "text-gray-500 hover:text-gray-700"
+                      }`}
+                    >
+                      Unmatched ({unmatchedReceipts.length})
+                    </button>
+                    <button
+                      onClick={() => setReviewTab("matched")}
+                      className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
+                        reviewTab === "matched"
+                          ? "text-[#3D8E62] border-b-2 border-[#3D8E62] bg-[#EEF7F2]/30"
+                          : "text-gray-500 hover:text-gray-700"
+                      }`}
+                    >
+                      Matched ({matchedReceipts.length})
+                    </button>
+                  </div>
+
+                  {/* Tab Content */}
+                  <div className="divide-y divide-gray-50">
+                    {reviewTab === "unmatched" && (
+                      <>
+                        {unmatchedReceipts.length === 0 ? (
+                          <div className="p-8 text-center">
+                            <CheckCircle2 className="w-8 h-8 text-[#3D8E62] mx-auto mb-2" />
+                            <p className="text-sm text-gray-500">All receipts are matched!</p>
+                          </div>
+                        ) : (
+                          unmatchedReceipts.map((receipt) => (
+                            <div key={receipt.id} className="p-4">
+                              <div className="flex items-center justify-between">
+                                <div className="flex-1 min-w-0">
+                                  <div className="flex items-center gap-2">
+                                    <h4 className="text-sm font-semibold text-gray-900 truncate">{receipt.merchant}</h4>
+                                    <span className="px-2 py-0.5 bg-amber-50 text-amber-600 text-xs rounded-full font-medium shrink-0">
+                                      Unmatched
+                                    </span>
+                                  </div>
+                                  <p className="text-xs text-gray-500 mt-0.5">
+                                    {new Date(receipt.date).toLocaleDateString()} &bull;{" "}
+                                    {formatCurrency(
+                                      receipt.currency && receipt.currency !== currencyCode
+                                        ? convertCurrency(receipt.amount, receipt.currency, currencyCode)
+                                        : receipt.amount,
+                                      currencyCode
+                                    )}
+                                  </p>
+                                </div>
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    if (findingMatchFor === receipt.id) {
+                                      setFindingMatchFor(null);
+                                      setCandidates([]);
+                                    } else {
+                                      findCandidates(receipt);
+                                    }
+                                  }}
+                                  className="px-3 py-1.5 text-xs font-medium rounded-lg bg-[#EEF7F2] text-[#3D8E62] hover:bg-[#D1EAE0] transition-colors flex items-center gap-1.5 shrink-0"
+                                >
+                                  <Search className="w-3 h-3" />
+                                  {findingMatchFor === receipt.id ? "Cancel" : "Find Match"}
+                                </button>
+                              </div>
+
+                              {/* Candidate transactions dropdown */}
+                              <AnimatePresence>
+                                {findingMatchFor === receipt.id && (
+                                  <motion.div
+                                    initial={{ opacity: 0, height: 0 }}
+                                    animate={{ opacity: 1, height: "auto" }}
+                                    exit={{ opacity: 0, height: 0 }}
+                                    transition={{ duration: 0.15 }}
+                                    className="overflow-hidden"
+                                  >
+                                    <div className="mt-3 bg-gray-50 rounded-lg border border-gray-100 p-3">
+                                      <p className="text-xs font-medium text-gray-500 mb-2">Matching transactions:</p>
+                                      {loadingCandidates ? (
+                                        <div className="flex items-center justify-center py-4">
+                                          <Loader2 className="w-4 h-4 animate-spin text-gray-400" />
+                                          <span className="text-xs text-gray-400 ml-2">Searching...</span>
+                                        </div>
+                                      ) : candidates.length === 0 ? (
+                                        <p className="text-xs text-gray-400 py-3 text-center">
+                                          No matching transactions found within 10% amount and 7 days.
+                                        </p>
+                                      ) : (
+                                        <div className="space-y-1.5">
+                                          {candidates.map((tx) => (
+                                            <div
+                                              key={tx.dbId}
+                                              className="flex items-center justify-between p-2.5 bg-white rounded-lg border border-gray-100 hover:border-[#3D8E62]/30 transition-colors"
+                                            >
+                                              <div className="flex-1 min-w-0">
+                                                <p className="text-sm font-medium text-gray-900 truncate">{tx.merchant}</p>
+                                                <p className="text-xs text-gray-500">
+                                                  {tx.dateStr} &bull;{" "}
+                                                  {formatCurrency(
+                                                    Math.abs(tx.amount),
+                                                    tx.isoCurrencyCode || currencyCode
+                                                  )}
+                                                </p>
+                                              </div>
+                                              <button
+                                                onClick={(e) => {
+                                                  e.stopPropagation();
+                                                  matchReceipt(receipt.id, tx.dbId);
+                                                }}
+                                                disabled={matchingReceipt === receipt.id}
+                                                className="px-3 py-1.5 text-xs font-medium rounded-lg bg-[#3D8E62] text-white hover:bg-[#2D7A52] disabled:opacity-50 transition-colors flex items-center gap-1 shrink-0"
+                                              >
+                                                {matchingReceipt === receipt.id ? (
+                                                  <Loader2 className="w-3 h-3 animate-spin" />
+                                                ) : (
+                                                  <ArrowRight className="w-3 h-3" />
+                                                )}
+                                                Match
+                                              </button>
+                                            </div>
+                                          ))}
+                                        </div>
+                                      )}
+                                    </div>
+                                  </motion.div>
+                                )}
+                              </AnimatePresence>
+                            </div>
+                          ))
+                        )}
+                      </>
+                    )}
+
+                    {reviewTab === "matched" && (
+                      <>
+                        {matchedReceipts.length === 0 ? (
+                          <div className="p-8 text-center">
+                            <p className="text-sm text-gray-500">No matched receipts yet.</p>
+                          </div>
+                        ) : (
+                          matchedReceipts.map((receipt) => (
+                            <div key={receipt.id} className="p-4">
+                              <div className="flex items-center justify-between">
+                                <div className="flex-1 min-w-0">
+                                  <div className="flex items-center gap-2">
+                                    <h4 className="text-sm font-semibold text-gray-900 truncate">{receipt.merchant}</h4>
+                                    <span className="px-2 py-0.5 bg-[#EEF7F2] text-[#3D8E62] text-xs rounded-full font-medium shrink-0">
+                                      Matched
+                                    </span>
+                                  </div>
+                                  <p className="text-xs text-gray-500 mt-0.5">
+                                    {new Date(receipt.date).toLocaleDateString()} &bull;{" "}
+                                    {formatCurrency(
+                                      receipt.currency && receipt.currency !== currencyCode
+                                        ? convertCurrency(receipt.amount, receipt.currency, currencyCode)
+                                        : receipt.amount,
+                                      currencyCode
+                                    )}
+                                  </p>
+                                </div>
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    unmatchReceipt(receipt.id);
+                                  }}
+                                  disabled={matchingReceipt === receipt.id}
+                                  className="px-3 py-1.5 text-xs font-medium rounded-lg bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 disabled:opacity-50 transition-colors flex items-center gap-1.5 shrink-0"
+                                >
+                                  {matchingReceipt === receipt.id ? (
+                                    <Loader2 className="w-3 h-3 animate-spin" />
+                                  ) : (
+                                    <Unlink className="w-3 h-3" />
+                                  )}
+                                  Unmatch
+                                </button>
+                              </div>
+                            </div>
+                          ))
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
         {/* Receipts List — full width when detail opens in modal */}
         <div className="space-y-4">
           <h3 className="text-sm font-semibold text-gray-700">Recent Receipts</h3>
@@ -481,7 +810,7 @@ function EmailReceiptsContent() {
                             currencyCode
                           )}
                         </p>
-                        <ChevronRight className="w-4 h-4 text-gray-400 ml-auto" />
+                        <ChevronRight className="w-4 h-4 text-gray-400 ml-auto mt-1" />
                       </div>
                     </div>
                   </motion.div>

--- a/app/app/shared/page.tsx
+++ b/app/app/shared/page.tsx
@@ -5,6 +5,7 @@ import {
   Plus,
   ArrowLeft,
   ChevronRight,
+  ChevronDown,
   X,
   CheckCircle2,
   Wallet,
@@ -562,6 +563,10 @@ function SharedPageContent() {
   const [addMemberError, setAddMemberError] = useState<string | null>(null);
   const [requestingPayment, setRequestingPayment] = useState(false);
   const [recordingSettlement, setRecordingSettlement] = useState(false);
+  const [editingHandlesMemberId, setEditingHandlesMemberId] = useState<string | null>(null);
+  const [handlesDraft, setHandlesDraft] = useState<{ venmo: string; cashapp: string; paypal: string }>({ venmo: "", cashapp: "", paypal: "" });
+  const [savingHandles, setSavingHandles] = useState(false);
+  const [handlesSaved, setHandlesSaved] = useState<string | null>(null);
   const [settleHandles, setSettleHandles] = useState<{
     venmo_username?: string | null;
     cashapp_cashtag?: string | null;
@@ -711,6 +716,44 @@ function SharedPageContent() {
       refetchGroupDetail();
     } else {
       setAddMemberError(data.error ?? "Failed to add member");
+    }
+  };
+
+  const toggleEditHandles = (memberId: string, member: { venmo_username?: string | null; cashapp_cashtag?: string | null; paypal_username?: string | null }) => {
+    if (editingHandlesMemberId === memberId) {
+      setEditingHandlesMemberId(null);
+      return;
+    }
+    setEditingHandlesMemberId(memberId);
+    setHandlesDraft({
+      venmo: member.venmo_username ?? "",
+      cashapp: member.cashapp_cashtag ?? "",
+      paypal: member.paypal_username ?? "",
+    });
+  };
+
+  const saveHandles = async (memberId: string) => {
+    if (!selectedId) return;
+    setSavingHandles(true);
+    try {
+      const res = await fetch(`/api/groups/${selectedId}/members`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          memberId,
+          venmo_username: handlesDraft.venmo.trim() || null,
+          cashapp_cashtag: handlesDraft.cashapp.trim() || null,
+          paypal_username: handlesDraft.paypal.trim() || null,
+        }),
+      });
+      if (res.ok) {
+        setHandlesSaved(memberId);
+        refetchGroupDetail();
+        setTimeout(() => setHandlesSaved(null), 2000);
+        setEditingHandlesMemberId(null);
+      }
+    } finally {
+      setSavingHandles(false);
     }
   };
 
@@ -902,13 +945,82 @@ function SharedPageContent() {
             </div>
             {addMemberError && <p className="text-sm text-red-600 mb-2">{addMemberError}</p>}
             <div className="space-y-1.5">
-              {groupDetail.members.map((m, i) => (
-                <div key={m.id} className="flex items-center gap-2 text-sm">
-                  <Avatar initials={m.display_name.slice(0, 2).toUpperCase()} color={MEMBER_COLORS[i % MEMBER_COLORS.length]} size="sm" />
-                  <span className="font-medium">{m.display_name}</span>
-                  {m.email && <span className="text-gray-500 text-xs">{m.email}</span>}
-                </div>
-              ))}
+              {groupDetail.members.map((m, i) => {
+                const isEditing = editingHandlesMemberId === m.id;
+                const justSaved = handlesSaved === m.id;
+                const hasHandles = m.venmo_username || m.cashapp_cashtag || m.paypal_username;
+                return (
+                  <div key={m.id} className="rounded-xl border border-gray-100 overflow-hidden">
+                    <div className="flex items-center gap-2 text-sm px-3 py-2.5">
+                      <Avatar initials={m.display_name.slice(0, 2).toUpperCase()} color={MEMBER_COLORS[i % MEMBER_COLORS.length]} size="sm" />
+                      <div className="flex-1 min-w-0">
+                        <span className="font-medium">{m.display_name}</span>
+                        {m.email && <span className="text-gray-500 text-xs ml-1.5">{m.email}</span>}
+                        {hasHandles && !isEditing && (
+                          <div className="flex gap-2 mt-0.5">
+                            {m.venmo_username && <span className="text-[10px] text-gray-400">Venmo: {m.venmo_username}</span>}
+                            {m.cashapp_cashtag && <span className="text-[10px] text-gray-400">Cash: {m.cashapp_cashtag}</span>}
+                            {m.paypal_username && <span className="text-[10px] text-gray-400">PayPal: {m.paypal_username}</span>}
+                          </div>
+                        )}
+                      </div>
+                      {justSaved ? (
+                        <span className="flex items-center gap-1 text-xs text-[#3D8E62] font-medium">
+                          <CheckCircle2 size={14} /> Saved
+                        </span>
+                      ) : (
+                        <button
+                          onClick={() => toggleEditHandles(m.id, m)}
+                          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 transition-colors px-1.5 py-1 rounded-md hover:bg-gray-50"
+                        >
+                          {isEditing ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                          <span>{isEditing ? "Close" : "Payment handles"}</span>
+                        </button>
+                      )}
+                    </div>
+                    {isEditing && (
+                      <div className="px-3 pb-3 pt-1 border-t border-gray-100 bg-gray-50/50">
+                        <div className="space-y-2">
+                          <div>
+                            <label className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Venmo</label>
+                            <input
+                              value={handlesDraft.venmo}
+                              onChange={(e) => setHandlesDraft((d) => ({ ...d, venmo: e.target.value }))}
+                              placeholder="@username"
+                              className="w-full mt-0.5 px-3 py-2 rounded-lg border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-[#3D8E62]/20 focus:border-[#3D8E62] bg-white"
+                            />
+                          </div>
+                          <div>
+                            <label className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Cash App</label>
+                            <input
+                              value={handlesDraft.cashapp}
+                              onChange={(e) => setHandlesDraft((d) => ({ ...d, cashapp: e.target.value }))}
+                              placeholder="$cashtag"
+                              className="w-full mt-0.5 px-3 py-2 rounded-lg border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-[#3D8E62]/20 focus:border-[#3D8E62] bg-white"
+                            />
+                          </div>
+                          <div>
+                            <label className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">PayPal</label>
+                            <input
+                              value={handlesDraft.paypal}
+                              onChange={(e) => setHandlesDraft((d) => ({ ...d, paypal: e.target.value }))}
+                              placeholder="username"
+                              className="w-full mt-0.5 px-3 py-2 rounded-lg border border-gray-200 text-sm focus:outline-none focus:ring-2 focus:ring-[#3D8E62]/20 focus:border-[#3D8E62] bg-white"
+                            />
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => saveHandles(m.id)}
+                          disabled={savingHandles}
+                          className="mt-3 w-full py-2 rounded-lg bg-[#3D8E62] hover:bg-[#2D7A52] disabled:opacity-50 text-white text-sm font-medium transition-colors"
+                        >
+                          {savingHandles ? "Saving\u2026" : "Save handles"}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}

--- a/hooks/useGroups.ts
+++ b/hooks/useGroups.ts
@@ -16,6 +16,9 @@ export interface GroupMember {
   user_id: string | null;
   email: string | null;
   display_name: string;
+  venmo_username?: string | null;
+  cashapp_cashtag?: string | null;
+  paypal_username?: string | null;
 }
 
 export interface GroupDetail extends Group {

--- a/lib/__tests__/item-insights.test.ts
+++ b/lib/__tests__/item-insights.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock supabase before importing the module under test
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockGte = vi.fn();
+
+let mockResult: { data: unknown[]; error: null } = { data: [], error: null };
+
+vi.mock("../supabase", () => ({
+  getSupabase: () => ({
+    from: () => ({
+      select: (...args: unknown[]) => {
+        mockSelect(...args);
+        return {
+          eq: (...eqArgs: unknown[]) => {
+            mockEq(...eqArgs);
+            return {
+              gte: (...gteArgs: unknown[]) => {
+                mockGte(...gteArgs);
+                return mockResult;
+              },
+            };
+          },
+        };
+      },
+    }),
+  }),
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { detectItemTrends } from "../item-insights";
+
+function setMockData(data: unknown[]) {
+  mockResult = { data, error: null };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResult = { data: [], error: null };
+});
+
+describe("detectItemTrends", () => {
+  it("returns empty array when no receipts exist", async () => {
+    setMockData([]);
+    const result = await detectItemTrends("user_123");
+    expect(result).toEqual([]);
+  });
+
+  it("detects repeat purchases (3+ times)", async () => {
+    setMockData([
+      { merchant: "Walmart", date: "2026-03-01", line_items: [{ name: "Milk", quantity: 1, total: 4.99, category: "groceries" }] },
+      { merchant: "Walmart", date: "2026-03-05", line_items: [{ name: "milk", quantity: 1, total: 5.29, category: "groceries" }] },
+      { merchant: "Target", date: "2026-03-10", line_items: [{ name: " Milk ", quantity: 1, total: 4.79, category: "groceries" }] },
+    ]);
+
+    const result = await detectItemTrends("user_123");
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const repeat = result.find((i) => i.type === "repeat_purchase");
+    expect(repeat).toBeDefined();
+    expect(repeat!.message).toContain("milk");
+    expect(repeat!.message).toContain("3 times");
+  });
+
+  it("detects high-spend items (> $50)", async () => {
+    setMockData([
+      { merchant: "Best Buy", date: "2026-03-01", line_items: [{ name: "AirPods Pro", quantity: 1, total: 249.99, category: "electronics" }] },
+    ]);
+
+    const result = await detectItemTrends("user_123");
+    const highSpend = result.find((i) => i.type === "high_spend_item");
+    expect(highSpend).toBeDefined();
+    expect(highSpend!.message).toContain("AirPods Pro");
+    expect(highSpend!.message).toContain("Best Buy");
+  });
+
+  it("detects merchant sub-category breakdown with 3+ receipts", async () => {
+    setMockData([
+      { merchant: "Walmart", date: "2026-03-01", line_items: [{ name: "Bananas", quantity: 1, total: 2.50, category: "groceries" }] },
+      { merchant: "Walmart", date: "2026-03-05", line_items: [{ name: "Dish Soap", quantity: 1, total: 3.99, category: "household" }] },
+      { merchant: "Walmart", date: "2026-03-10", line_items: [{ name: "Bread", quantity: 1, total: 2.99, category: "groceries" }] },
+    ]);
+
+    const result = await detectItemTrends("user_123");
+    const breakdown = result.find((i) => i.type === "merchant_breakdown");
+    expect(breakdown).toBeDefined();
+    expect(breakdown!.message).toContain("Walmart");
+    expect(breakdown!.message).toMatch(/\d+% groceries/);
+  });
+
+  it("returns at most 3 insights", async () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      merchant: "Store",
+      date: "2026-03-01",
+      line_items: [
+        { name: `Item${i}`, quantity: 3, total: 99.99, category: `cat${i}` },
+      ],
+    }));
+    setMockData(items);
+
+    const result = await detectItemTrends("user_123");
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it("handles missing or malformed line_items gracefully", async () => {
+    setMockData([
+      { merchant: "Store", date: "2026-03-01", line_items: null },
+      { merchant: "Store", date: "2026-03-02", line_items: "not an array" },
+      { merchant: "Store", date: "2026-03-03", line_items: [{ name: null, total: 10 }] },
+    ]);
+
+    const result = await detectItemTrends("user_123");
+    // Should not throw, just return empty or gracefully handle
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/lib/google-auth.ts
+++ b/lib/google-auth.ts
@@ -1,5 +1,6 @@
 import { google } from "googleapis";
 import { getSupabase } from "./supabase";
+import { encryptToken, decryptToken } from "./encryption";
 
 const SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"];
 
@@ -43,8 +44,8 @@ export async function saveGmailTokens(
   const { data, error } = await db.from("gmail_connections").upsert(
     {
       clerk_user_id: clerkUserId,
-      access_token: tokens.access_token ?? "",
-      refresh_token: tokens.refresh_token ?? "",
+      access_token: tokens.access_token ? encryptToken(tokens.access_token) : "",
+      refresh_token: tokens.refresh_token ? encryptToken(tokens.refresh_token) : "",
       token_expiry: tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null,
       email: email ?? null,
     },
@@ -71,16 +72,16 @@ export async function getGmailClient(clerkUserId: string) {
 
   const client = getOAuth2Client();
   client.setCredentials({
-    access_token: data.access_token,
-    refresh_token: data.refresh_token,
+    access_token: data.access_token ? decryptToken(data.access_token) : undefined,
+    refresh_token: data.refresh_token ? decryptToken(data.refresh_token) : undefined,
     expiry_date: data.token_expiry ? new Date(data.token_expiry).getTime() : undefined,
   });
 
   // Auto-refresh: when tokens refresh, persist them
   client.on("tokens", async (tokens) => {
     const updates: Record<string, string> = {};
-    if (tokens.access_token) updates.access_token = tokens.access_token;
-    if (tokens.refresh_token) updates.refresh_token = tokens.refresh_token;
+    if (tokens.access_token) updates.access_token = encryptToken(tokens.access_token);
+    if (tokens.refresh_token) updates.refresh_token = encryptToken(tokens.refresh_token);
     if (tokens.expiry_date) updates.token_expiry = new Date(tokens.expiry_date).toISOString();
     if (Object.keys(updates).length > 0) {
       try {

--- a/lib/item-insights.ts
+++ b/lib/item-insights.ts
@@ -1,0 +1,171 @@
+/**
+ * Item-Level Insights
+ *
+ * Analyzes receipt line items to surface granular purchasing patterns:
+ * - Repeat purchases (items bought 3+ times this month)
+ * - High-spend items (single items > $50)
+ * - Merchant sub-category breakdown (for merchants with 3+ receipts)
+ */
+
+import { getSupabase } from "./supabase";
+
+export interface ItemInsight {
+  type: "repeat_purchase" | "high_spend_item" | "merchant_breakdown";
+  message: string;
+  detail?: string;
+}
+
+interface LineItem {
+  name?: string;
+  quantity?: number;
+  unit_price?: number;
+  total?: number;
+  price?: number;
+  category?: string;
+}
+
+interface ReceiptRow {
+  merchant: string | null;
+  line_items: unknown;
+  date: string | null;
+}
+
+function normalizeItemName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function fmt(amount: number): string {
+  return amount.toLocaleString("en-US", { style: "currency", currency: "USD" });
+}
+
+export async function detectItemTrends(
+  clerkUserId: string
+): Promise<ItemInsight[]> {
+  const db = getSupabase();
+
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .split("T")[0];
+
+  const { data, error } = await db
+    .from("email_receipts")
+    .select("merchant, line_items, date")
+    .eq("clerk_user_id", clerkUserId)
+    .gte("date", monthStart);
+
+  if (error) {
+    console.error("[item-insights] query failed:", error);
+    return [];
+  }
+
+  if (!data?.length) return [];
+  const receipts = data as ReceiptRow[];
+
+  // Track items across all receipts
+  const itemAgg = new Map<string, { count: number; total: number; merchants: Set<string> }>();
+  // Track high-spend individual items
+  const highSpendItems: Array<{ name: string; merchant: string; price: number }> = [];
+  // Track receipts per merchant for breakdown
+  const merchantReceipts = new Map<string, { count: number; categories: Map<string, number> }>();
+
+  for (const receipt of receipts) {
+    const merchant = (receipt.merchant || "Unknown").trim();
+    const items = Array.isArray(receipt.line_items) ? (receipt.line_items as LineItem[]) : [];
+
+    // Merchant receipt count
+    if (!merchantReceipts.has(merchant)) {
+      merchantReceipts.set(merchant, { count: 0, categories: new Map() });
+    }
+    const mr = merchantReceipts.get(merchant)!;
+    mr.count++;
+
+    for (const item of items) {
+      const rawName = item.name;
+      if (!rawName || typeof rawName !== "string") continue;
+
+      const normalized = normalizeItemName(rawName);
+      if (!normalized) continue;
+
+      const quantity = Number(item.quantity) || 1;
+      const itemTotal = Number(item.total) || Number(item.price) || Number(item.unit_price) || 0;
+
+      // Aggregate by item name
+      const existing = itemAgg.get(normalized) ?? { count: 0, total: 0, merchants: new Set() };
+      existing.count += quantity;
+      existing.total += itemTotal;
+      existing.merchants.add(merchant);
+      itemAgg.set(normalized, existing);
+
+      // High-spend check (per-item total, not quantity-adjusted unit price)
+      if (itemTotal > 50) {
+        highSpendItems.push({ name: rawName.trim(), merchant, price: itemTotal });
+      }
+
+      // Merchant category breakdown
+      const cat = (item.category || "other").trim().toLowerCase();
+      mr.categories.set(cat, (mr.categories.get(cat) ?? 0) + itemTotal);
+    }
+  }
+
+  const insights: ItemInsight[] = [];
+
+  // 1. Repeat purchases (3+ times this month)
+  const repeats = Array.from(itemAgg.entries())
+    .filter(([, v]) => v.count >= 3)
+    .sort((a, b) => b[1].count - a[1].count);
+
+  for (const [name, data] of repeats.slice(0, 2)) {
+    const displayName = name.length > 40 ? name.slice(0, 37) + "..." : name;
+    insights.push({
+      type: "repeat_purchase",
+      message: `You've bought ${displayName} ${data.count} times this month (${fmt(data.total)})`,
+      detail: data.merchants.size > 1
+        ? `Across ${data.merchants.size} merchants`
+        : `At ${Array.from(data.merchants)[0]}`,
+    });
+  }
+
+  // 2. High-spend items (> $50)
+  const sortedHighSpend = highSpendItems.sort((a, b) => b.price - a.price);
+  for (const item of sortedHighSpend.slice(0, 2)) {
+    insights.push({
+      type: "high_spend_item",
+      message: `Big purchase: ${item.name} at ${item.merchant} (${fmt(item.price)})`,
+    });
+  }
+
+  // 3. Merchant sub-category breakdown (3+ receipts)
+  const merchantBreakdowns = Array.from(merchantReceipts.entries())
+    .filter(([, v]) => v.count >= 3 && v.categories.size > 1)
+    .sort((a, b) => b[1].count - a[1].count);
+
+  for (const [merchant, data] of merchantBreakdowns.slice(0, 1)) {
+    const totalSpend = Array.from(data.categories.values()).reduce((s, v) => s + v, 0);
+    if (totalSpend <= 0) continue;
+
+    const breakdown = Array.from(data.categories.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([cat, amount]) => {
+        const pct = Math.round((amount / totalSpend) * 100);
+        return `${pct}% ${cat}`;
+      })
+      .join(", ");
+
+    insights.push({
+      type: "merchant_breakdown",
+      message: `Your ${merchant} spending: ${breakdown}`,
+      detail: `${data.count} receipts this month`,
+    });
+  }
+
+  // Return max 3, prioritized: repeats first, then breakdowns, then high-spend
+  const prioritized: ItemInsight[] = [
+    ...insights.filter((i) => i.type === "repeat_purchase"),
+    ...insights.filter((i) => i.type === "merchant_breakdown"),
+    ...insights.filter((i) => i.type === "high_spend_item"),
+  ];
+
+  return prioritized.slice(0, 3);
+}

--- a/lib/receipt-parser.ts
+++ b/lib/receipt-parser.ts
@@ -126,6 +126,9 @@ export async function parseReceiptEmail(emailBody: string): Promise<{
   merchant: string;
   order_date: string;
   total_amount: number;
+  subtotal: number | null;
+  tax: number | null;
+  order_number: string | null;
   line_items: Array<{ name: string; quantity: number; unit_price: number; total: number; category: string }>;
 } | null> {
   if (!openai) {
@@ -174,14 +177,21 @@ Rules:
 - Look for the ACTUAL amount paid, not placeholder values
 - Extract merchant name from sender or subject if not in body
 - All numeric values must be numbers, not strings
+- Extract subtotal (pre-tax amount), tax, and order_number if present; use null if not found
+- Assign each line item a category from this list of Plaid-compatible categories:
+  FOOD_AND_DRINK, GROCERIES, ENTERTAINMENT, SHOPPING, TRANSPORTATION,
+  HEALTH_AND_FITNESS, HOUSEHOLD, ELECTRONICS, PERSONAL_CARE, OTHER
 
 Schema:
 {
   "merchant": "store/company/service name",
   "order_date": "YYYY-MM-DD",
   "total_amount": number,
+  "subtotal": number | null,
+  "tax": number | null,
+  "order_number": "string or null",
   "line_items": [
-    {"name": "item/service name", "quantity": 1, "unit_price": 9.99, "total": 9.99, "category": "category"}
+    {"name": "item/service name", "quantity": 1, "unit_price": 9.99, "total": 9.99, "category": "GROCERIES"}
   ]
 }
 
@@ -205,6 +215,9 @@ ${body}`
     merchant?: string;
     total_amount?: number;
     order_date?: string;
+    subtotal?: number | null;
+    tax?: number | null;
+    order_number?: string | null;
     line_items?: Array<Record<string, unknown>>;
   };
   try {
@@ -218,20 +231,29 @@ ${body}`
   if (!parsed.merchant) return null;
   if (!parsed.total_amount || parsed.total_amount <= 0) return null;
 
+  const VALID_CATEGORIES = new Set([
+    "FOOD_AND_DRINK", "GROCERIES", "ENTERTAINMENT", "SHOPPING", "TRANSPORTATION",
+    "HEALTH_AND_FITNESS", "HOUSEHOLD", "ELECTRONICS", "PERSONAL_CARE", "OTHER",
+  ]);
+
   return {
     merchant: parsed.merchant,
     order_date: parsed.order_date || new Date().toISOString().split("T")[0],
     total_amount: Number(parsed.total_amount) || 0,
+    subtotal: parsed.subtotal != null ? Number(parsed.subtotal) || null : null,
+    tax: parsed.tax != null ? Number(parsed.tax) || null : null,
+    order_number: parsed.order_number ? String(parsed.order_number) : null,
     line_items: (parsed.line_items || []).map((item: Record<string, unknown>) => {
       const quantity = Number(item.quantity) || 1;
       const unit_price = Number(item.unit_price) || Number(item.price) || 0;
       const total = Number(item.total) || (unit_price * quantity);
+      const rawCategory = String(item.category || "OTHER").toUpperCase();
       return {
         name: String(item.name || "Item"),
         quantity,
         unit_price,
         total,
-        category: String(item.category || "other"),
+        category: VALID_CATEGORIES.has(rawCategory) ? rawCategory : "OTHER",
       };
     }),
   };
@@ -413,6 +435,9 @@ export async function scanGmailForReceipts(
           line_items: receiptData.line_items,
           raw_subject: subject,
           raw_from: from,
+          ...(receiptData.subtotal != null && { subtotal: receiptData.subtotal }),
+          ...(receiptData.tax != null && { tax: receiptData.tax }),
+          ...(receiptData.order_number != null && { order_number: receiptData.order_number }),
         };
 
         const { data: inserted, error: insertError } = forceRescan

--- a/supabase/migrations/20250319_add_receipt_metadata.sql
+++ b/supabase/migrations/20250319_add_receipt_metadata.sql
@@ -1,0 +1,4 @@
+alter table email_receipts add column if not exists subtotal numeric(14,2);
+alter table email_receipts add column if not exists tax numeric(14,2);
+alter table email_receipts add column if not exists order_number text;
+alter table email_receipts add column if not exists match_source text default 'auto';

--- a/supabase/migrations/20250319_drop_p2p_transactions.sql
+++ b/supabase/migrations/20250319_drop_p2p_transactions.sql
@@ -1,0 +1,2 @@
+-- p2p_transactions is no longer used. All P2P data is in the main transactions table.
+drop table if exists p2p_transactions cascade;


### PR DESCRIPTION
## Summary
- **Gmail token encryption**: OAuth tokens encrypted at rest with AES-256-GCM via `lib/encryption.ts`
- **P2P handle editing**: Edit Venmo/CashApp/PayPal usernames per group member in Shared page
- **Receipt match review**: Manual match/unmatch UI in Email Receipts page with candidate search
- **AI item categorization**: Receipt parser now extracts per-item Plaid categories, subtotal, tax, order number
- **Item-level analytics**: Dashboard shows repeat purchase detection, high-spend item alerts, merchant category breakdowns
- **Drop p2p_transactions table**: Consolidated into main `transactions` table with `source` column
- **2 new migrations** to run: `20250319_add_receipt_metadata.sql` and `20250319_drop_p2p_transactions.sql`

## Files changed
- `lib/google-auth.ts` — encrypt/decrypt Gmail tokens
- `app/app/shared/page.tsx`, `hooks/useGroups.ts`, `app/api/groups/[id]/route.ts` — P2P handle editing
- `app/api/email-receipts/[id]/match/route.ts`, `app/app/email-receipts/page.tsx` — receipt match/unmatch
- `lib/receipt-parser.ts` — AI item categorization
- `lib/item-insights.ts`, `app/api/insights/items/route.ts` — item analytics engine + API
- `app/app/dashboard/page.tsx` — item insights card
- `lib/__tests__/item-insights.test.ts` — 6 tests for item insights

## Test plan
- [x] `tsc --noEmit` passes (only pre-existing friends-flow.test.ts errors)
- [x] `vitest run` — 186 tests pass across 26 files
- [ ] Run 2 new migrations on Supabase
- [ ] Verify Gmail token encryption works (connect Gmail, check tokens are encrypted in DB)
- [ ] Test P2P handle editing in Shared page
- [ ] Test receipt match/unmatch in Email Receipts page
- [ ] Verify item insights show on dashboard after scanning receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)