### PR TITLE
fix(security): prevent cross-user data leak via route caching

### DIFF
--- a/app/api/auth/handoff-token/route.ts
+++ b/app/api/auth/handoff-token/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { auth } from "@clerk/nextjs/server";
 import { clerkClient } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";

--- a/app/api/auth/return-to-app-token/route.ts
+++ b/app/api/auth/return-to-app-token/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { auth } from "@clerk/nextjs/server";
 import { clerkClient } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";

--- a/app/api/categorize/route.ts
+++ b/app/api/categorize/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { enrichCategoriesForUser } from "@/lib/transaction-sync";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/csv-import/route.ts
+++ b/app/api/csv-import/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabaseAdmin, getSupabaseForUser } from "@/lib/supabase";
@@ -132,6 +133,8 @@ export async function GET() {
       subscriptions: { totalMonthly, count: subs.length, upcomingBills },
       accounts: accountList,
       wallets,
+    }, {
+      headers: { "Cache-Control": "no-store, max-age=0" },
     });
   } catch (err) {
     console.error("[dashboard] error:", err instanceof Error ? err.message : err);

--- a/app/api/debug/me/route.ts
+++ b/app/api/debug/me/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 

--- a/app/api/debug/rls/route.ts
+++ b/app/api/debug/rls/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabaseAdmin, getSupabaseForUser } from "@/lib/supabase";

--- a/app/api/email-receipts/[id]/match/route.ts
+++ b/app/api/email-receipts/[id]/match/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/email-receipts/by-transaction/route.ts
+++ b/app/api/email-receipts/by-transaction/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/email-receipts/route.ts
+++ b/app/api/email-receipts/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/gmail/auth/route.ts
+++ b/app/api/gmail/auth/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getAuthUrl } from "@/lib/google-auth";

--- a/app/api/gmail/callback/route.ts
+++ b/app/api/gmail/callback/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { exchangeCode, saveGmailTokens, getOAuth2Client } from "@/lib/google-auth";

--- a/app/api/gmail/debug-amazon/route.ts
+++ b/app/api/gmail/debug-amazon/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getGmailClient } from "@/lib/google-auth";

--- a/app/api/gmail/disconnect/route.ts
+++ b/app/api/gmail/disconnect/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { removeGmailConnection } from "@/lib/google-auth";

--- a/app/api/gmail/scan/route.ts
+++ b/app/api/gmail/scan/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { scanGmailForReceipts } from "@/lib/receipt-parser";

--- a/app/api/gmail/status/route.ts
+++ b/app/api/gmail/status/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getGmailStatus } from "@/lib/google-auth";

--- a/app/api/groups/[id]/members/route.ts
+++ b/app/api/groups/[id]/members/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getUserId } from "@/lib/auth";

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { clerkClient } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/groups/[id]/settlements/route.ts
+++ b/app/api/groups/[id]/settlements/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/groups/people/route.ts
+++ b/app/api/groups/people/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/groups/person/route.ts
+++ b/app/api/groups/person/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { computeBalances, getSuggestedSettlements } from "@/lib/split-balances";

--- a/app/api/groups/recent-activity/route.ts
+++ b/app/api/groups/recent-activity/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getAccessibleGroupIds } from "@/lib/group-access";

--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { currentUser } from "@clerk/nextjs/server";
 import { randomUUID } from "crypto";

--- a/app/api/insights/items/route.ts
+++ b/app/api/insights/items/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getEffectiveUserId } from "@/lib/demo";
 import { detectItemTrends } from "@/lib/item-insights";

--- a/app/api/insights/route.ts
+++ b/app/api/insights/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getEffectiveUserId } from "@/lib/demo";
 import { generateInsights } from "@/lib/insights-engine";

--- a/app/api/manual-accounts/route.ts
+++ b/app/api/manual-accounts/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/manual-expense/route.ts
+++ b/app/api/manual-expense/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/nl-parse/route.ts
+++ b/app/api/nl-parse/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import OpenAI from "openai";

--- a/app/api/nl-search/route.ts
+++ b/app/api/nl-search/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { search } from "@/lib/search-engine";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/p2p-annotation/route.ts
+++ b/app/api/p2p-annotation/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/paypal/auth/route.ts
+++ b/app/api/paypal/auth/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getEffectiveUserId } from "@/lib/demo";
 import { getAuthUrl } from "@/lib/paypal-auth";

--- a/app/api/paypal/callback/route.ts
+++ b/app/api/paypal/callback/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { exchangeCode, savePayPalTokens, verifyOAuthState } from "@/lib/paypal-auth";

--- a/app/api/paypal/disconnect/route.ts
+++ b/app/api/paypal/disconnect/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getEffectiveUserId } from "@/lib/demo";
 import { removePayPalConnection } from "@/lib/paypal-auth";

--- a/app/api/paypal/status/route.ts
+++ b/app/api/paypal/status/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getEffectiveUserId } from "@/lib/demo";
 import { getPayPalStatus } from "@/lib/paypal-auth";

--- a/app/api/paypal/sync/route.ts
+++ b/app/api/paypal/sync/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/plaid/clear-alerts/route.ts
+++ b/app/api/plaid/clear-alerts/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/plaid/create-link-token/route.ts
+++ b/app/api/plaid/create-link-token/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getPlaidClient } from "@/lib/plaid-client";
 import { getPlaidConfig } from "@/lib/plaid";

--- a/app/api/plaid/debug/route.ts
+++ b/app/api/plaid/debug/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { Configuration, PlaidApi, PlaidEnvironments } from "plaid";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/plaid/disconnect/route.ts
+++ b/app/api/plaid/disconnect/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/plaid/exchange-token/route.ts
+++ b/app/api/plaid/exchange-token/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getPlaidClient } from "@/lib/plaid-client";

--- a/app/api/plaid/link-events/route.ts
+++ b/app/api/plaid/link-events/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { getEffectiveUserId } from "@/lib/demo";
 

--- a/app/api/plaid/status/route.ts
+++ b/app/api/plaid/status/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getEffectiveUserId } from "@/lib/demo";

--- a/app/api/plaid/transactions/route.ts
+++ b/app/api/plaid/transactions/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { auth } from "@clerk/nextjs/server";
@@ -207,7 +208,9 @@ export async function GET(request: NextRequest) {
     });
 
     console.log("[pipeline:tx] GET output", { count: mapped.length });
-    return NextResponse.json(mapped);
+    return NextResponse.json(mapped, {
+      headers: { "Cache-Control": "no-store, max-age=0" },
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[pipeline:tx] GET error:", err);

--- a/app/api/plaid/wipe/route.ts
+++ b/app/api/plaid/wipe/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/receipt/[id]/assign/route.ts
+++ b/app/api/receipt/[id]/assign/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/receipt/[id]/finish/route.ts
+++ b/app/api/receipt/[id]/finish/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { revalidateTag } from "next/cache";

--- a/app/api/receipt/[id]/items/route.ts
+++ b/app/api/receipt/[id]/items/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/receipt/parse/route.ts
+++ b/app/api/receipt/parse/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/recurring-expenses/route.ts
+++ b/app/api/recurring-expenses/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getUserId } from "@/lib/auth";

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { searchTransactions } from "@/lib/search";
 import { SEARCH } from "@/lib/config";

--- a/app/api/search/v2/backfill/route.ts
+++ b/app/api/search/v2/backfill/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 /**
  * Backfill endpoint for search v2.
  *

--- a/app/api/search/v2/route.ts
+++ b/app/api/search/v2/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { searchV2 } from "@/lib/search/engine";

--- a/app/api/settlements/route.ts
+++ b/app/api/settlements/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getSupabase } from "@/lib/supabase";

--- a/app/api/split-transactions/[id]/route.ts
+++ b/app/api/split-transactions/[id]/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { revalidateTag } from "next/cache";

--- a/app/api/split-transactions/route.ts
+++ b/app/api/split-transactions/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { revalidateTag } from "next/cache";

--- a/app/api/stripe/create-payment-link/route.ts
+++ b/app/api/stripe/create-payment-link/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import Stripe from "stripe";

--- a/app/api/stripe/terminal/connection-token/route.ts
+++ b/app/api/stripe/terminal/connection-token/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import Stripe from "stripe";

--- a/app/api/stripe/terminal/create-payment-intent/route.ts
+++ b/app/api/stripe/terminal/create-payment-intent/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import Stripe from "stripe";

--- a/app/api/stripe/terminal/location/route.ts
+++ b/app/api/stripe/terminal/location/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import Stripe from "stripe";

--- a/app/api/subscriptions/[id]/route.ts
+++ b/app/api/subscriptions/[id]/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { revalidateTag } from "next/cache";

--- a/app/api/subscriptions/route.ts
+++ b/app/api/subscriptions/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { revalidateTag } from "next/cache";


### PR DESCRIPTION
## Summary
**P0 Security Fix** — Users could see other users' financial data (transactions, balances, subscriptions) due to Next.js/Vercel caching GET route responses across sessions.

- Added `export const dynamic = "force-dynamic"` to **all 62 auth-dependent API routes**
- Added `Cache-Control: no-store` headers to `/api/dashboard` and `/api/plaid/transactions` as defense-in-depth
- Only 2 of 62 routes previously had `force-dynamic` set

## Root cause
Next.js App Router can statically cache Route Handler GET responses at the Vercel CDN layer. Without `force-dynamic`, a cached response from user A could be served to user B. While `auth()` calls opt routes into dynamic rendering at the Next.js level, the Vercel CDN layer can still cache responses unless explicitly told not to.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Log in as user A → verify you see only your own transactions
- [ ] Log in as user B → verify you see only your own transactions
- [ ] Hard refresh on dashboard — data should always be fresh and user-specific

🤖 Generated with [Claude Code](https://claude.com/claude-code)