### PR TITLE
feat: improve email receipt matching quality + integration tests

### DIFF
--- a/app/api/debug/receipt-match-verify/route.ts
+++ b/app/api/debug/receipt-match-verify/route.ts
@@ -269,8 +269,6 @@ export async function GET() {
     } | null;
   }> = [];
 
-  const windowDays = RECEIPT_MATCH.DATE_WINDOW_DAYS;
-
   for (const receipt of unmatchedReceiptRows) {
     if (!receipt.merchant || !receipt.amount) continue;
 
@@ -282,9 +280,9 @@ export async function GET() {
     if (receipt.date) {
       const dateObj = new Date(receipt.date);
       const start = new Date(dateObj);
-      start.setDate(start.getDate() - windowDays);
+      start.setDate(start.getDate() - RECEIPT_MATCH.WINDOW_BEFORE_DAYS);
       const end = new Date(dateObj);
-      end.setDate(end.getDate() + windowDays);
+      end.setDate(end.getDate() + RECEIPT_MATCH.WINDOW_AFTER_DAYS);
       dateStart = start.toISOString().split("T")[0];
       dateEnd = end.toISOString().split("T")[0];
     }

--- a/app/api/email-receipts/[id]/match/route.ts
+++ b/app/api/email-receipts/[id]/match/route.ts
@@ -29,25 +29,28 @@ export async function POST(
 
   const db = getSupabase();
 
-  // Verify receipt ownership
-  const { data: receipt, error: receiptError } = await db
-    .from("email_receipts")
-    .select("id")
-    .eq("id", id)
-    .eq("clerk_user_id", userId)
-    .single();
+  // Verify receipt + transaction ownership in parallel
+  const [
+    { data: receipt, error: receiptError },
+    { data: transaction, error: txError },
+  ] = await Promise.all([
+    db
+      .from("email_receipts")
+      .select("id")
+      .eq("id", id)
+      .eq("clerk_user_id", userId)
+      .single(),
+    db
+      .from("transactions")
+      .select("id")
+      .eq("id", transactionId)
+      .eq("clerk_user_id", userId)
+      .single(),
+  ]);
 
   if (receiptError || !receipt) {
     return NextResponse.json({ error: "Receipt not found" }, { status: 404 });
   }
-
-  // Verify transaction ownership
-  const { data: transaction, error: txError } = await db
-    .from("transactions")
-    .select("id")
-    .eq("id", transactionId)
-    .eq("clerk_user_id", userId)
-    .single();
 
   if (txError || !transaction) {
     return NextResponse.json({ error: "Transaction not found" }, { status: 404 });

--- a/app/api/email-receipts/[id]/route.ts
+++ b/app/api/email-receipts/[id]/route.ts
@@ -86,5 +86,5 @@ export async function GET(
         sort_order: index,
       };
     }),
-  });
+  }, { headers: { "Cache-Control": "private, max-age=300, stale-while-revalidate=600" } });
 }

--- a/app/api/groups/[id]/export/route.ts
+++ b/app/api/groups/[id]/export/route.ts
@@ -60,23 +60,39 @@ export async function GET(
 
   const db = getSupabase();
 
-  const { data: group, error: groupErr } = await db
-    .from("groups")
-    .select("name")
-    .eq("id", groupId)
-    .single();
+  const [
+    { data: group, error: groupErr },
+    { data: membersRaw, error: memErr },
+    { data: splitsRaw, error: splitErr },
+  ] = await Promise.all([
+    db.from("groups").select("name").eq("id", groupId).single(),
+    db
+      .from("group_members")
+      .select("id, display_name, user_id")
+      .eq("group_id", groupId)
+      .order("display_name", { ascending: true, nullsFirst: false })
+      .order("id", { ascending: true }),
+    db
+      .from("split_transactions")
+      .select(
+        `
+      id, transaction_id, created_at, payer_member_id, amount, description,
+      iso_currency_code,
+      transactions(merchant_name, raw_name, amount, date)
+    `
+      )
+      .eq("group_id", groupId)
+      .order("created_at", { ascending: true }),
+  ]);
+
   if (groupErr || !group) return NextResponse.json({ error: "Not found" }, { status: 404 });
-
-  const { data: membersRaw, error: memErr } = await db
-    .from("group_members")
-    .select("id, display_name, user_id")
-    .eq("group_id", groupId)
-    .order("display_name", { ascending: true, nullsFirst: false })
-    .order("id", { ascending: true });
-
   if (memErr) {
     console.error("[groups/export] members:", memErr.message);
     return NextResponse.json({ error: "Failed to load group" }, { status: 500 });
+  }
+  if (splitErr) {
+    console.error("[groups/export] splits:", splitErr.message);
+    return NextResponse.json({ error: "Failed to load expenses" }, { status: 500 });
   }
 
   const members = membersRaw ?? [];
@@ -84,23 +100,6 @@ export async function GET(
   const memberByUserId = new Map(
     members.filter((m) => m.user_id).map((m) => [m.user_id as string, m.id])
   );
-
-  const { data: splitsRaw, error: splitErr } = await db
-    .from("split_transactions")
-    .select(
-      `
-      id, transaction_id, created_at, payer_member_id, amount, description,
-      iso_currency_code,
-      transactions(merchant_name, raw_name, amount, date)
-    `
-    )
-    .eq("group_id", groupId)
-    .order("created_at", { ascending: true });
-
-  if (splitErr) {
-    console.error("[groups/export] splits:", splitErr.message);
-    return NextResponse.json({ error: "Failed to load expenses" }, { status: 500 });
-  }
 
   const seenTxIds = new Set<string>();
   const splits = (splitsRaw ?? []).filter((s) => {
@@ -111,26 +110,24 @@ export async function GET(
   });
 
   const txIds = splits.map((s) => s.transaction_id).filter(Boolean) as string[];
-  let txRows: { id: string; clerk_user_id: string }[] = [];
-  if (txIds.length > 0) {
-    const { data } = await db.from("transactions").select("id, clerk_user_id").in("id", txIds);
-    txRows = data ?? [];
-  }
-  const txOwnerById = new Map(txRows.map((t) => [t.id, t.clerk_user_id]));
-
   const splitIds = splits.map((s) => s.id);
-  let shares: { split_transaction_id: string; member_id: string; amount: number | string }[] = [];
-  if (splitIds.length > 0) {
-    const { data: sh, error: shErr } = await db
-      .from("split_shares")
-      .select("split_transaction_id, member_id, amount")
-      .in("split_transaction_id", splitIds);
-    if (shErr) {
-      console.error("[groups/export] shares:", shErr.message);
-      return NextResponse.json({ error: "Failed to load shares" }, { status: 500 });
-    }
-    shares = sh ?? [];
+
+  const [{ data: txData }, { data: sh, error: shErr }] = await Promise.all([
+    txIds.length > 0
+      ? db.from("transactions").select("id, clerk_user_id").in("id", txIds)
+      : Promise.resolve({ data: [] as { id: string; clerk_user_id: string }[], error: null }),
+    splitIds.length > 0
+      ? db.from("split_shares").select("split_transaction_id, member_id, amount").in("split_transaction_id", splitIds)
+      : Promise.resolve({ data: [] as { split_transaction_id: string; member_id: string; amount: number | string }[], error: null }),
+  ]);
+
+  if (shErr) {
+    console.error("[groups/export] shares:", shErr.message);
+    return NextResponse.json({ error: "Failed to load shares" }, { status: 500 });
   }
+  const txRows = txData ?? [];
+  const shares = sh ?? [];
+  const txOwnerById = new Map(txRows.map((t) => [t.id, t.clerk_user_id]));
 
   const sharesBySplit = new Map<string, Map<string, number>>();
   for (const sh of shares) {
@@ -156,7 +153,7 @@ export async function GET(
     const tid = s.transaction_id as string | null | undefined;
     const payerMemberId = (s as { payer_member_id?: string | null }).payer_member_id;
     const resolvedPayerId =
-      payerMemberId && members.some((m) => m.id === payerMemberId)
+      payerMemberId && memberMap.has(payerMemberId)
         ? payerMemberId
         : (() => {
             const ownerId = tid ? txOwnerById.get(tid) : undefined;

--- a/app/api/groups/[id]/members/[memberId]/route.ts
+++ b/app/api/groups/[id]/members/[memberId]/route.ts
@@ -13,17 +13,13 @@ export async function DELETE(
   const { id, memberId } = await params;
   const db = getSupabase();
 
-  const { data: group, error: groupError } = await db.from("groups").select("owner_id").eq("id", id).single();
+  const [{ data: group, error: groupError }, { data: member, error: memberError }] = await Promise.all([
+    db.from("groups").select("owner_id").eq("id", id).single(),
+    db.from("group_members").select("id, user_id").eq("id", memberId).eq("group_id", id).maybeSingle(),
+  ]);
   if (groupError || !group || group.owner_id !== userId) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
-
-  const { data: member, error: memberError } = await db
-    .from("group_members")
-    .select("id, user_id")
-    .eq("id", memberId)
-    .eq("group_id", id)
-    .maybeSingle();
 
   if (memberError) {
     console.error("[members/memberId] lookup:", memberError.message);

--- a/app/api/groups/[id]/members/route.ts
+++ b/app/api/groups/[id]/members/route.ts
@@ -179,7 +179,10 @@ export async function DELETE(
   const { id } = await params;
   const db = getSupabase();
 
-  const { data: group, error: groupError } = await db.from("groups").select("owner_id").eq("id", id).single();
+  const [{ data: group, error: groupError }, { data: membership, error: membershipError }] = await Promise.all([
+    db.from("groups").select("owner_id").eq("id", id).single(),
+    db.from("group_members").select("id").eq("group_id", id).eq("user_id", userId).maybeSingle(),
+  ]);
   if (groupError || !group) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
@@ -189,14 +192,6 @@ export async function DELETE(
       { status: 400 }
     );
   }
-
-  const { data: membership, error: membershipError } = await db
-    .from("group_members")
-    .select("id")
-    .eq("group_id", id)
-    .eq("user_id", userId)
-    .maybeSingle();
-
   if (membershipError) {
     console.error("[members] leave lookup:", membershipError.message);
     return NextResponse.json({ error: "Operation failed" }, { status: 500 });

--- a/app/api/invite/[token]/join/route.ts
+++ b/app/api/invite/[token]/join/route.ts
@@ -39,12 +39,15 @@ export async function POST(
     });
   }
 
-  const { data: existing } = await db
-    .from("group_members")
-    .select("id")
-    .eq("group_id", group.id)
-    .eq("user_id", userId)
-    .maybeSingle();
+  const [{ data: existing }, user] = await Promise.all([
+    db
+      .from("group_members")
+      .select("id")
+      .eq("group_id", group.id)
+      .eq("user_id", userId)
+      .maybeSingle(),
+    currentUser(),
+  ]);
 
   if (existing) {
     return NextResponse.json({
@@ -55,7 +58,6 @@ export async function POST(
     });
   }
 
-  const user = await currentUser();
   const email = user?.primaryEmailAddress?.emailAddress ?? null;
   const displayName = user?.fullName || user?.firstName || "Member";
 

--- a/app/api/plaid/debug/route.ts
+++ b/app/api/plaid/debug/route.ts
@@ -41,17 +41,16 @@ export async function GET() {
   try {
     const db = getSupabase();
 
-    // plaid_items count
-    const { count: plaidCount } = await db
-      .from("plaid_items")
-      .select("id", { count: "exact", head: true })
-      .eq("clerk_user_id", effectiveUserId);
-
-    // accounts count
-    const { count: accountsCount } = await db
-      .from("accounts")
-      .select("id", { count: "exact", head: true })
-      .eq("clerk_user_id", effectiveUserId);
+    const [{ count: plaidCount }, { count: accountsCount }] = await Promise.all([
+      db
+        .from("plaid_items")
+        .select("id", { count: "exact", head: true })
+        .eq("clerk_user_id", effectiveUserId),
+      db
+        .from("accounts")
+        .select("id", { count: "exact", head: true })
+        .eq("clerk_user_id", effectiveUserId),
+    ]);
 
     // Try Plaid accountsGet for first token + verify which env it belongs to
     let plaidError: string | null = null;
@@ -79,25 +78,18 @@ export async function GET() {
       // Verify: try token with sandbox and/or production to detect mismatch.
       // In production, never call sandbox API (Plaid production checklist).
       const prodClient = createPlaidClientForEnv("production");
-      if (prodClient) {
-        try {
-          await prodClient.accountsGet({ access_token: accessToken });
-          token_works_in_production = true;
-        } catch {
-          token_works_in_production = false;
-        }
-      }
-      if (PLAID_ENV !== "production") {
-        const sandboxClient = createPlaidClientForEnv("sandbox");
-        if (sandboxClient) {
-          try {
-            await sandboxClient.accountsGet({ access_token: accessToken });
-            token_works_in_sandbox = true;
-          } catch {
-            token_works_in_sandbox = false;
-          }
-        }
-      }
+      const sandboxClient = PLAID_ENV !== "production" ? createPlaidClientForEnv("sandbox") : null;
+
+      const [prodResult, sandboxResult] = await Promise.all([
+        prodClient
+          ? prodClient.accountsGet({ access_token: accessToken }).then(() => true).catch(() => false)
+          : Promise.resolve(null as boolean | null),
+        sandboxClient
+          ? sandboxClient.accountsGet({ access_token: accessToken }).then(() => true).catch(() => false)
+          : Promise.resolve(null as boolean | null),
+      ]);
+      token_works_in_production = prodResult;
+      token_works_in_sandbox = sandboxResult;
     }
 
     const env_mismatch =

--- a/app/api/receipt/[id]/assign/route.ts
+++ b/app/api/receipt/[id]/assign/route.ts
@@ -35,23 +35,23 @@ export async function POST(
 
   const db = getSupabase();
 
-  // Verify ownership
-  const { data: receipt, error: receiptError } = await db
-    .from("receipt_scans")
-    .select("id")
-    .eq("id", id)
-    .eq("clerk_user_id", userId)
-    .single();
+  // Verify ownership and fetch item ids in parallel
+  const [{ data: receipt, error: receiptError }, { data: receiptItems }] = await Promise.all([
+    db
+      .from("receipt_scans")
+      .select("id")
+      .eq("id", id)
+      .eq("clerk_user_id", userId)
+      .single(),
+    db
+      .from("receipt_items")
+      .select("id")
+      .eq("receipt_id", id),
+  ]);
 
   if (receiptError || !receipt) {
     return NextResponse.json({ error: "Receipt not found" }, { status: 404 });
   }
-
-  // Get item ids for this receipt
-  const { data: receiptItems } = await db
-    .from("receipt_items")
-    .select("id")
-    .eq("receipt_id", id);
 
   const validItemIds = new Set((receiptItems ?? []).map((i) => i.id));
 
@@ -86,12 +86,10 @@ export async function POST(
     }
   }
 
-  if (rows.length > 0) {
-    await db.from("receipt_assignments").insert(rows);
-  }
-
-  // Update status
-  await db.from("receipt_scans").update({ status: "assigned" }).eq("id", id);
+  await Promise.all([
+    rows.length > 0 ? db.from("receipt_assignments").insert(rows) : Promise.resolve(null),
+    db.from("receipt_scans").update({ status: "assigned" }).eq("id", id),
+  ]);
 
   return NextResponse.json({ ok: true });
 }

--- a/app/api/receipt/[id]/items/route.ts
+++ b/app/api/receipt/[id]/items/route.ts
@@ -47,10 +47,11 @@ export async function PUT(
   if (Array.isArray(other_fees)) {
     updatePayload.other_fees = other_fees;
   }
-  await db.from("receipt_scans").update(updatePayload).eq("id", id).eq("clerk_user_id", userId);
-
-  // Replace all items
-  await db.from("receipt_items").delete().eq("receipt_id", id);
+  // Update receipt totals and delete existing items in parallel
+  await Promise.all([
+    db.from("receipt_scans").update(updatePayload).eq("id", id).eq("clerk_user_id", userId),
+    db.from("receipt_items").delete().eq("receipt_id", id),
+  ]);
 
   if (Array.isArray(items) && items.length > 0) {
     const itemRows = items.map(

--- a/app/api/stripe/connect/create-account/route.ts
+++ b/app/api/stripe/connect/create-account/route.ts
@@ -26,11 +26,14 @@ export async function POST(req: Request) {
     const stripe = new Stripe(key);
     const db = getSupabase();
 
-    const { data: existing, error: selectError } = await db
-      .from("stripe_connected_accounts")
-      .select("stripe_account_id, onboarding_complete")
-      .eq("clerk_user_id", userId)
-      .maybeSingle();
+    const [{ data: existing, error: selectError }, user] = await Promise.all([
+      db
+        .from("stripe_connected_accounts")
+        .select("stripe_account_id, onboarding_complete")
+        .eq("clerk_user_id", userId)
+        .maybeSingle(),
+      currentUser(),
+    ]);
 
     if (selectError) {
       console.error("[stripe-connect] db select failed:", selectError);
@@ -42,7 +45,6 @@ export async function POST(req: Request) {
     if (existing) {
       accountId = existing.stripe_account_id;
     } else {
-      const user = await currentUser();
       const email = user?.emailAddresses?.[0]?.emailAddress ?? undefined;
       const firstName = user?.firstName ?? undefined;
       const lastName = user?.lastName ?? undefined;

--- a/app/api/user/tier/route.ts
+++ b/app/api/user/tier/route.ts
@@ -21,5 +21,5 @@ export async function GET() {
     .eq("clerk_user_id", clerkAuth.userId)
     .single();
 
-  return NextResponse.json({ tier: data?.tier ?? "free" });
+  return NextResponse.json({ tier: data?.tier ?? "free" }, { headers: { "Cache-Control": "private, max-age=300, stale-while-revalidate=600" } });
 }

--- a/lib/__tests__/receipt-matcher.test.ts
+++ b/lib/__tests__/receipt-matcher.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for lib/receipt-matcher.ts
+ *
+ * Covers normalizeMerchant, merchantsMatch, extractKeywords, scoreCandidates,
+ * and realistic receipt→transaction match scenarios.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  normalizeMerchant,
+  merchantsMatch,
+  extractKeywords,
+  scoreCandidates,
+} from "../receipt-matcher";
+
+// ─── normalizeMerchant ────────────────────────────────────────────────────────
+
+describe("normalizeMerchant", () => {
+  describe("POS prefix stripping", () => {
+    it("strips SQ * (Square)", () => {
+      expect(normalizeMerchant("SQ *MENSHO")).toBe("mensho");
+      expect(normalizeMerchant("SQ *Blue Bottle Coffee")).toBe("blue bottle coffee");
+    });
+    it("strips SQ* without space", () => {
+      expect(normalizeMerchant("SQ*TARTINE")).toBe("tartine");
+    });
+    it("strips TST* (Toast)", () => {
+      expect(normalizeMerchant("TST*TACOLICIOUS")).toBe("tacolicious");
+    });
+    it("strips TST (space) prefix", () => {
+      expect(normalizeMerchant("TST DUMPLING TIME")).toBe("dumpling time");
+    });
+    it("strips SP * (Shopify)", () => {
+      expect(normalizeMerchant("SP *Allbirds")).toBe("allbirds");
+    });
+    it("strips PP * (PayPal)", () => {
+      expect(normalizeMerchant("PP *STUBHUB")).toBe("stubhub");
+    });
+    it("strips AMZN* prefix", () => {
+      expect(normalizeMerchant("AMZN*MKTP US")).toBe("mktp us");
+    });
+    it("strips PayPal (space) prefix", () => {
+      expect(normalizeMerchant("PayPal EBAY")).toBe("ebay");
+    });
+    it("strips Google* prefix", () => {
+      expect(normalizeMerchant("Google *YouTube Premium")).toBe("youtube premium");
+    });
+    it("strips CHECKCARD prefix", () => {
+      expect(normalizeMerchant("CHECKCARD 0412 COSTCO WHSE")).toBe("0412 costco whse");
+    });
+    it("strips POS prefix", () => {
+      expect(normalizeMerchant("POS WALMART SUPERCENTER")).toBe("walmart supercenter");
+    });
+    it("is case-insensitive for prefix matching", () => {
+      expect(normalizeMerchant("sq *Blue Bottle")).toBe("blue bottle");
+    });
+  });
+
+  describe("character normalization", () => {
+    it("lowercases result", () => {
+      expect(normalizeMerchant("STARBUCKS")).toBe("starbucks");
+    });
+    it("strips apostrophes", () => {
+      expect(normalizeMerchant("McDonald's")).toBe("mcdonalds");
+      expect(normalizeMerchant("Trader Joe's")).toBe("trader joes");
+      expect(normalizeMerchant("Lowe's")).toBe("lowes");
+    });
+    it("collapses multiple spaces", () => {
+      expect(normalizeMerchant("HOME   DEPOT")).toBe("home depot");
+    });
+    it("trims whitespace", () => {
+      expect(normalizeMerchant("  Nike  ")).toBe("nike");
+    });
+  });
+
+  describe("numeric merchants", () => {
+    it("preserves numbers", () => {
+      expect(normalizeMerchant("7-Eleven")).toBe("7eleven");
+      expect(normalizeMerchant("76 Gas")).toBe("76 gas");
+    });
+    it("preserves numbers after POS stripping", () => {
+      expect(normalizeMerchant("SQ *7-Eleven")).toBe("7eleven");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      expect(normalizeMerchant("")).toBe("");
+    });
+    it("handles all-punctuation string", () => {
+      expect(normalizeMerchant("***---***")).toBe("");
+    });
+  });
+});
+
+// ─── merchantsMatch ───────────────────────────────────────────────────────────
+
+describe("merchantsMatch", () => {
+  describe("substring containment", () => {
+    it("matches when one normalized form contains the other", () => {
+      expect(merchantsMatch("Starbucks", "STARBUCKS COFFEE 1234")).toBe(true);
+    });
+    it("returns false for unrelated merchants", () => {
+      expect(merchantsMatch("Shell", "Sheraton Hotel")).toBe(false);
+    });
+    it("returns false when either input is empty", () => {
+      expect(merchantsMatch("", "Starbucks")).toBe(false);
+      expect(merchantsMatch("Starbucks", "")).toBe(false);
+    });
+  });
+
+  describe("keyword matching", () => {
+    it("matches on shared keyword >= 3 chars", () => {
+      expect(merchantsMatch("Chipotle Mexican Grill", "CHIPOTLE 2341")).toBe(true);
+      expect(merchantsMatch("Best Buy", "BEST BUY #432")).toBe(true);
+    });
+  });
+
+  describe("POS prefix stripping", () => {
+    it("matches SQ * prefixed tx name against plain receipt merchant", () => {
+      expect(merchantsMatch("Mensho Tokyo SF", "SQ *MENSHO")).toBe(true);
+    });
+    it("matches TST* prefixed tx name against plain receipt merchant", () => {
+      expect(merchantsMatch("Tacolicious", "TST*TACOLICIOUS")).toBe(true);
+    });
+    it("matches AMZN* tx against Amazon receipt", () => {
+      expect(merchantsMatch("Amazon", "AMZN*MKTP US")).toBe(true);
+    });
+  });
+
+  describe("alias-based matching", () => {
+    it("matches Uber variants", () => {
+      expect(merchantsMatch("Uber", "UBER TRIP")).toBe(true);
+      expect(merchantsMatch("Uber Eats", "UBER EATS")).toBe(true);
+    });
+    it("matches Amazon variants", () => {
+      expect(merchantsMatch("Amazon", "AMZN MKTP")).toBe(true);
+    });
+    it("matches Trader Joe's variants", () => {
+      expect(merchantsMatch("Trader Joe's", "TRADER JOE")).toBe(true);
+    });
+    it("matches Whole Foods variants", () => {
+      expect(merchantsMatch("Whole Foods Market", "WHOLEFDS SFO")).toBe(true);
+      expect(merchantsMatch("WFM", "Whole Foods")).toBe(true);
+    });
+    it("matches Walmart variants", () => {
+      expect(merchantsMatch("Walmart", "WAL-MART")).toBe(true);
+      expect(merchantsMatch("Walmart.com", "WM SUPERCENTER #1234")).toBe(true);
+    });
+    it("matches Home Depot variants", () => {
+      expect(merchantsMatch("Home Depot", "THE HOME DEPOT #0604")).toBe(true);
+    });
+    it("matches Delta Airlines variants", () => {
+      expect(merchantsMatch("Delta Airlines", "DELTA AIR")).toBe(true);
+    });
+    it("matches DoorDash variants", () => {
+      expect(merchantsMatch("DoorDash", "DD DOORDASH")).toBe(true);
+    });
+    it("matches Grubhub / Seamless as same group", () => {
+      expect(merchantsMatch("Grubhub", "SEAMLESS")).toBe(true);
+      expect(merchantsMatch("Seamless", "Grubhub")).toBe(true);
+    });
+    it("matches OpenAI / ChatGPT", () => {
+      expect(merchantsMatch("OpenAI", "OPENAI CHATGPT")).toBe(true);
+    });
+    it("does NOT match different alias groups", () => {
+      expect(merchantsMatch("Airbnb", "Clipper")).toBe(false);
+      expect(merchantsMatch("Netflix", "Spotify")).toBe(false);
+      expect(merchantsMatch("Lyft", "Uber")).toBe(false);
+      expect(merchantsMatch("Delta", "United Airlines")).toBe(false);
+    });
+  });
+
+  describe("short merchant names", () => {
+    it("matches CVS via substring", () => {
+      expect(merchantsMatch("CVS", "CVS PHARMACY #4532")).toBe(true);
+    });
+    it("matches HEB via substring", () => {
+      expect(merchantsMatch("HEB", "HEB GAS #0012")).toBe(true);
+    });
+  });
+
+  describe("numeric merchants", () => {
+    it("matches 7-Eleven variants", () => {
+      expect(merchantsMatch("7-Eleven", "7-ELEVEN 34567")).toBe(true);
+    });
+  });
+});
+
+// ─── extractKeywords ──────────────────────────────────────────────────────────
+
+describe("extractKeywords", () => {
+  it("filters stop words", () => {
+    const kws = extractKeywords("The Store Online");
+    expect(kws).not.toContain("the");
+    expect(kws).not.toContain("store");
+    expect(kws).not.toContain("online");
+  });
+
+  it("filters tokens shorter than MIN_KEYWORD_LENGTH", () => {
+    const kws = extractKeywords("BP Gas");
+    expect(kws).not.toContain("bp");
+    expect(kws).toContain("gas");
+  });
+
+  it("deduplicates keywords", () => {
+    const kws = extractKeywords("Amazon Amazon");
+    expect(kws.filter((k) => k === "amazon").length).toBe(1);
+  });
+
+  it("injects alias canonical keys", () => {
+    expect(extractKeywords("Amazon")).toContain("amazon");
+    expect(extractKeywords("Uber Eats")).toContain("uber");
+  });
+
+  it("injects all alias tokens, not just first word", () => {
+    // "trader joe" alias → both "trader" and "joe" should be available
+    const kws = extractKeywords("Trader Joe's");
+    expect(kws).toContain("trader");
+    expect(kws).toContain("joe");
+  });
+
+  it("caps result at MAX_KEYWORDS (7)", () => {
+    const kws = extractKeywords("Starbucks Coffee Roasters International Premium Blend Reserve");
+    expect(kws.length).toBeLessThanOrEqual(7);
+  });
+
+  it("handles POS-prefixed merchant name", () => {
+    const kws = extractKeywords("SQ *Blue Bottle Coffee");
+    expect(kws).toContain("blue");
+    expect(kws).toContain("bottle");
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(extractKeywords("")).toEqual([]);
+  });
+
+  it("strips ILIKE-unsafe characters from keywords", () => {
+    for (const kw of extractKeywords("H&M Store 50% off")) {
+      expect(kw).not.toMatch(/[%_\\]/);
+    }
+  });
+});
+
+// ─── scoreCandidates ─────────────────────────────────────────────────────────
+
+describe("scoreCandidates", () => {
+  const date = "2025-03-15";
+
+  function tx(id: string, amount: number, d: string, merchant: string) {
+    return { id, amount, date: d, normalized_merchant: merchant, merchant_name: merchant };
+  }
+
+  describe("tiered tolerance — merchant matched", () => {
+    it("accepts tx within $5 absolute tolerance", () => {
+      // $25 receipt, $28 tx — $3 diff < min($5, 10%*$25=$2.50) → $2.50... wait, $3 > $2.50
+      // Actually min($5, $2.50) = $2.50, so $3 diff is rejected. Let's use $27 ($2 diff < $2.50).
+      expect(scoreCandidates([tx("t1", 27.00, date, "starbucks")], 25.00, date, "Starbucks")).toBe("t1");
+    });
+
+    it("accepts tx within 10% tolerance for larger amounts", () => {
+      // $100 receipt, $108 tx — diff $8 < min($5, 10%*$100=$10) = $5 → rejects at $8
+      // Use $104 (diff $4 < $5)
+      expect(scoreCandidates([tx("t1", 104.00, date, "amazon")], 100.00, date, "Amazon")).toBe("t1");
+    });
+
+    it("rejects tx outside min($5, 10%) tolerance", () => {
+      // $100 receipt, $115 tx — diff $15 > $5
+      expect(scoreCandidates([tx("t1", 115.00, date, "amazon")], 100.00, date, "Amazon")).toBeNull();
+    });
+  });
+
+  describe("tiered tolerance — no merchant match", () => {
+    it("rejects non-matching merchant regardless of amount", () => {
+      expect(scoreCandidates([tx("t1", 25.00, date, "lyft")], 25.00, date, "Starbucks")).toBeNull();
+    });
+
+    it("uses tight tolerance when no receiptMerchant provided", () => {
+      // $5 diff with no merchant → merchantMatched=false → exact $0.01 tolerance
+      expect(scoreCandidates([tx("t1", 30.00, date, "anymerchant")], 25.00, date, undefined)).toBeNull();
+    });
+
+    it("accepts exact match with no receiptMerchant", () => {
+      expect(scoreCandidates([tx("t1", 25.00, date, "anymerchant")], 25.00, date, undefined)).toBe("t1");
+    });
+  });
+
+  describe("sorting", () => {
+    it("picks closer amount when dates are equal", () => {
+      expect(scoreCandidates(
+        [tx("far", 28.00, date, "starbucks"), tx("near", 25.50, date, "starbucks")],
+        25.00, date, "Starbucks"
+      )).toBe("near");
+    });
+
+    it("picks closer date when amounts are equal", () => {
+      expect(scoreCandidates(
+        [tx("later", 25.00, "2025-03-20", "starbucks"), tx("sooner", 25.00, "2025-03-16", "starbucks")],
+        25.00, date, "Starbucks"
+      )).toBe("sooner");
+    });
+  });
+
+  it("returns null for empty candidates", () => {
+    expect(scoreCandidates([], 25.00, date, "Starbucks")).toBeNull();
+  });
+});
+
+// ─── Realistic match scenarios ────────────────────────────────────────────────
+
+describe("Realistic match scenarios", () => {
+  function tx(id: string, amount: number, date: string, merchant: string) {
+    return { id, amount, date, normalized_merchant: merchant, merchant_name: merchant };
+  }
+
+  it("SQ *MENSHO matches Mensho Tokyo SF receipt", () => {
+    expect(merchantsMatch("Mensho Tokyo SF", "SQ *MENSHO")).toBe(true);
+    expect(scoreCandidates(
+      [tx("wrong", 15.00, "2025-03-15", "some other"), tx("correct", 42.50, "2025-03-15", "mensho")],
+      42.50, "2025-03-14", "Mensho Tokyo SF"
+    )).toBe("correct");
+  });
+
+  it("Amazon receipt matches AMZN*MKTP US tx", () => {
+    expect(scoreCandidates(
+      [tx("wrong", 99.00, "2025-03-10", "target"), tx("correct", 45.99, "2025-03-12", "amzn mktp")],
+      45.99, "2025-03-11", "Amazon"
+    )).toBe("correct");
+  });
+
+  it("Lyft receipt matches LYFT *RIDE tx via alias", () => {
+    expect(merchantsMatch("Lyft", "LYFT *RIDE")).toBe(true);
+  });
+
+  it("prefers temporally closer tx when amounts are identical", () => {
+    expect(scoreCandidates(
+      [tx("old", 50.00, "2025-03-10", "starbucks"), tx("new", 50.00, "2025-03-16", "starbucks")],
+      50.00, "2025-03-15", "Starbucks"
+    )).toBe("new");
+  });
+
+  it("Airbnb receipt does NOT match Clipper tx (known conflict)", () => {
+    expect(merchantsMatch("Airbnb", "Clipper")).toBe(false);
+    expect(scoreCandidates(
+      [tx("clipper", 50.00, "2025-03-15", "clipper card")],
+      50.00, "2025-03-15", "Airbnb"
+    )).toBeNull();
+  });
+
+  it("CVS receipt matches CVS PHARMACY tx", () => {
+    expect(scoreCandidates(
+      [tx("t1", 12.50, "2025-03-15", "cvs pharmacy")],
+      12.50, "2025-03-15", "CVS"
+    )).toBe("t1");
+  });
+
+  it("Spotify receipt does not match Hulu tx (different groups)", () => {
+    expect(scoreCandidates(
+      [tx("hulu", 14.99, "2025-03-15", "hulu"), tx("spotify", 9.99, "2025-03-15", "spotify usa")],
+      9.99, "2025-03-15", "Spotify"
+    )).toBe("spotify");
+  });
+
+  it("Seamless receipt matches Grubhub tx via alias", () => {
+    expect(merchantsMatch("Seamless", "GRUBHUB")).toBe(true);
+  });
+
+  it("TST* restaurant receipt matches via POS stripping", () => {
+    expect(scoreCandidates(
+      [tx("t1", 67.40, "2025-03-15", "tartine manufactory")],
+      67.40, "2025-03-14", "TST*TARTINE MANUFACTORY"
+    )).toBe("t1");
+  });
+});

--- a/lib/__tests__/receipt-pipeline.test.ts
+++ b/lib/__tests__/receipt-pipeline.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Integration tests for the full email receipt pipeline:
+ *   Gmail API (mocked) → parseReceiptEmail (OpenAI mocked) → Supabase insert → match to transactions
+ *
+ * Covers:
+ *  - Pre-filters: excluded senders, Amazon shipped/delivered emails
+ *  - Merchant types: Starbucks (SQ * POS), Amazon (AMZN* tx), DoorDash, Spotify, Square restaurant
+ *  - Duplicate skipping: already-processed message IDs not re-parsed
+ *  - Match quality: correct transaction linked, NOT same-amount decoy
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── vi.hoisted runs BEFORE vi.mock factories and module evaluation ─────────────
+// Use it to: (1) set env so OpenAI client initializes, (2) build a mutable
+// create-mock that the OpenAI constructor can close over.
+const openaiMocks = vi.hoisted(() => {
+  process.env.OPENAI_API_KEY = "test-key-for-vitest";
+
+  // Mutable reference — tests swap this via setCreate()
+  let _create: (...args: unknown[]) => unknown = async () => ({
+    choices: [{ message: { content: '{"not_receipt":true}' } }],
+  });
+
+  // Regular function (not arrow) so it works with `new OpenAI()`
+  function OpenAIMock(this: unknown) {
+    return {
+      chat: { completions: { create: (...args: unknown[]) => _create(...args) } },
+    };
+  }
+
+  return {
+    OpenAIMock,
+    setCreate: (fn: typeof _create) => { _create = fn; },
+    resetCreate: () => {
+      _create = async () => ({
+        choices: [{ message: { content: '{"not_receipt":true}' } }],
+      });
+    },
+  };
+});
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("openai", () => ({ default: openaiMocks.OpenAIMock }));
+vi.mock("../google-auth", () => ({ getGmailClient: vi.fn() }));
+vi.mock("../supabase",    () => ({ getSupabase: vi.fn() }));
+vi.mock("../retry", () => ({
+  withRetry: vi.fn((fn: () => unknown) => fn()),
+  mapWithConcurrency: vi.fn(async (items: unknown[], fn: (item: unknown) => Promise<void>) => {
+    for (const item of items) await fn(item);
+  }),
+}));
+
+import { getGmailClient } from "../google-auth";
+import { getSupabase }    from "../supabase";
+import { withRetry, mapWithConcurrency } from "../retry";
+
+// ── Fake email bodies ──────────────────────────────────────────────────────────
+
+// Unique anchor strings used in setupParse() to route to the right parsed result
+const ANCHORS = {
+  starbucks: "STARBUCKS-RECEIPT-ANCHOR",
+  amazon:    "AMAZON-RECEIPT-ANCHOR",
+  doordash:  "DOORDASH-RECEIPT-ANCHOR",
+  spotify:   "SPOTIFY-RECEIPT-ANCHOR",
+  mensho:    "MENSHO-RECEIPT-ANCHOR",
+};
+
+const EMAIL = {
+  starbucks: `<h1>Starbucks Receipt ${ANCHORS.starbucks}</h1>
+    <p>Date: April 10, 2026</p>
+    <p>Grande Latte $6.25 | Blueberry Muffin $3.50 | Tax $0.85</p>
+    <p><strong>Total $10.60</strong></p>`,
+
+  amazon: `<h1>Amazon Order Confirmation ${ANCHORS.amazon}</h1>
+    <p>Order #112-5551234-9876543 placed April 11, 2026</p>
+    <p>Apple USB-C Cable $14.99 | Phone Stand $12.99 | Tax $2.52</p>
+    <p><strong>Order Total $30.50</strong></p>`,
+
+  doordash: `<h1>DoorDash Receipt ${ANCHORS.doordash}</h1>
+    <p>April 12, 2026 — Burma Bites</p>
+    <p>Chicken Noodle Soup $13.00 | Spring Rolls $9.00</p>
+    <p>Delivery $2.99 | Service fee $3.30 | Tip $5.00</p>
+    <p><strong>Total $33.29</strong></p>`,
+
+  spotify: `<p>Spotify Premium subscription renewed April 13, 2026 ${ANCHORS.spotify}</p>
+    <p><strong>Amount charged $11.99</strong></p>`,
+
+  mensho: `<h2>Receipt from Mensho Tokyo SF ${ANCHORS.mensho}</h2>
+    <p>April 9, 2026 — Ramen Tonkotsu $22.00 | Soft Drink $4.00 | Tax $2.34</p>
+    <p><strong>Total $28.34</strong></p>`,
+
+  investment: `<p>Your buy order for 10 shares of AAPL executed. Total $1,720.00</p>`,
+
+  amazonShipped: `<p>Your Amazon order has shipped! Tracking: 1Z999AA1</p>`,
+};
+
+// ── OpenAI parsed results (what the LLM would return) ────────────────────────
+
+const PARSED = {
+  starbucks: { merchant: "Starbucks", order_date: "2026-04-10", total_amount: 10.60, subtotal: 9.75, tax: 0.85, order_number: null, line_items: [{ name: "Grande Latte", quantity: 1, unit_price: 6.25, total: 6.25, category: "FOOD_AND_DRINK" }, { name: "Blueberry Muffin", quantity: 1, unit_price: 3.50, total: 3.50, category: "FOOD_AND_DRINK" }, { name: "Tax", quantity: 1, unit_price: 0.85, total: 0.85, category: "FOOD_AND_DRINK" }] },
+  amazon:    { merchant: "Amazon", order_date: "2026-04-11", total_amount: 30.50, subtotal: 27.98, tax: 2.52, order_number: "112-5551234-9876543", line_items: [{ name: "USB-C Cable", quantity: 1, unit_price: 14.99, total: 14.99, category: "ELECTRONICS" }, { name: "Phone Stand", quantity: 1, unit_price: 12.99, total: 12.99, category: "ELECTRONICS" }, { name: "Tax", quantity: 1, unit_price: 2.52, total: 2.52, category: "ELECTRONICS" }] },
+  doordash:  { merchant: "DoorDash", order_date: "2026-04-12", total_amount: 33.29, subtotal: 22.00, tax: null, order_number: null, line_items: [{ name: "Chicken Noodle Soup", quantity: 1, unit_price: 13.00, total: 13.00, category: "FOOD_AND_DRINK" }, { name: "Spring Rolls", quantity: 1, unit_price: 9.00, total: 9.00, category: "FOOD_AND_DRINK" }, { name: "Fees & Tip", quantity: 1, unit_price: 11.29, total: 11.29, category: "FOOD_AND_DRINK" }] },
+  spotify:   { merchant: "Spotify", order_date: "2026-04-13", total_amount: 11.99, subtotal: null, tax: null, order_number: null, line_items: [{ name: "Spotify Premium", quantity: 1, unit_price: 11.99, total: 11.99, category: "ENTERTAINMENT" }] },
+  mensho:    { merchant: "Mensho Tokyo SF", order_date: "2026-04-09", total_amount: 28.34, subtotal: 26.00, tax: 2.34, order_number: null, line_items: [{ name: "Ramen Tonkotsu", quantity: 1, unit_price: 22.00, total: 22.00, category: "FOOD_AND_DRINK" }, { name: "Soft Drink", quantity: 1, unit_price: 4.00, total: 4.00, category: "FOOD_AND_DRINK" }, { name: "Tax", quantity: 1, unit_price: 2.34, total: 2.34, category: "FOOD_AND_DRINK" }] },
+};
+
+// ── Fake Plaid transactions ────────────────────────────────────────────────────
+
+const FAKE_TXS = [
+  { id: "tx-sbux",    amount: 10.60, date: "2026-04-10", normalized_merchant: "starbucks",  merchant_name: "STARBUCKS #12345" },
+  { id: "tx-amzn",    amount: 30.50, date: "2026-04-12", normalized_merchant: "amzn mktp",  merchant_name: "AMZN*MKTP US" },
+  { id: "tx-dd",      amount: 33.29, date: "2026-04-13", normalized_merchant: "doordash",   merchant_name: "DOORDASH*BURMA" },
+  { id: "tx-spotify", amount: 11.99, date: "2026-04-13", normalized_merchant: "spotify",    merchant_name: "SPOTIFY USA" },
+  { id: "tx-mensho",  amount: 28.34, date: "2026-04-10", normalized_merchant: "mensho",     merchant_name: "SQ *MENSHO" },
+  // Decoy: same amount as Spotify, same day, different merchant
+  { id: "tx-decoy",   amount: 11.99, date: "2026-04-13", normalized_merchant: "hulu",       merchant_name: "HULU" },
+];
+
+// ── Gmail mock factory ─────────────────────────────────────────────────────────
+
+function makeMsg(id: string, from: string, subject: string, body: string) {
+  return {
+    data: {
+      id,
+      payload: {
+        headers: [{ name: "From", value: from }, { name: "Subject", value: subject }],
+        mimeType: "text/html",
+        body: { data: Buffer.from(body).toString("base64url") },
+      },
+    },
+  };
+}
+
+const MSGS: Record<string, ReturnType<typeof makeMsg>> = {
+  "msg-sbux":    makeMsg("msg-sbux",    "no-reply@starbucks.com",   "Your Starbucks receipt",              EMAIL.starbucks),
+  "msg-amazon":  makeMsg("msg-amazon",  "order-update@amazon.com",  "Ordered: Your Amazon order #112-555", EMAIL.amazon),
+  "msg-dd":      makeMsg("msg-dd",      "receipts@doordash.com",    "Your DoorDash receipt",               EMAIL.doordash),
+  "msg-spotify": makeMsg("msg-spotify", "no-reply@spotify.com",     "Your Spotify receipt",                EMAIL.spotify),
+  "msg-mensho":  makeMsg("msg-mensho",  "no-reply@squareup.com",    "Your receipt from Mensho Tokyo SF",   EMAIL.mensho),
+  "msg-invest":  makeMsg("msg-invest",  "noreply@questrade.com",    "Buy order executed: AAPL",            EMAIL.investment),
+  "msg-shipped": makeMsg("msg-shipped", "order-update@amazon.com",  "Your Amazon order has shipped!",      EMAIL.amazonShipped),
+};
+
+function gmail(ids: string[]) {
+  return {
+    users: {
+      messages: {
+        list: vi.fn().mockResolvedValue({ data: { messages: ids.map((id) => ({ id })) } }),
+        get: vi.fn().mockImplementation(async ({ id }: { id: string }) => {
+          if (!MSGS[id]) throw new Error(`Unknown msg id: ${id}`);
+          return MSGS[id];
+        }),
+      },
+    },
+  };
+}
+
+// ── Supabase stub ──────────────────────────────────────────────────────────────
+
+function makeDb(alreadyDone: string[] = []) {
+  const insertedReceipts: Record<string, unknown>[] = [];
+  const updatedMatches: Array<{ id: string; transaction_id: string }> = [];
+  let counter = 0;
+
+  function chain(val: unknown) {
+    const q: Record<string, unknown> = {};
+    const s = () => q;
+    q.select = s; q.eq = s; q.in = s; q.is = s;
+    q.not = s; q.gte = s; q.lte = s; q.maybeSingle = s;
+    q.then = (res: (v: unknown) => void) => { res(val); return Promise.resolve(val); };
+    return q;
+  }
+
+  const db = {
+    from: (table: string) => ({
+      select: (_cols?: string) => ({
+        // direct .in() — used by matchReceiptsToTransactions on email_receipts
+        in: (_c: string, ids: string[]) => ({
+          is: (_c2: string, _v2: unknown) => {
+            if (table === "email_receipts") {
+              const matched = insertedReceipts.filter((r) => ids.includes((r as Record<string,unknown>).id as string));
+              return chain({ data: matched, error: null });
+            }
+            return chain({ data: [], error: null });
+          },
+        }),
+        eq: (_c: string, _v: unknown) => ({
+          in: (_c2: string, ids: string[]) => {
+            if (table === "email_receipts" || table === "gmail_scan_log") {
+              const hits = ids.filter((id) => alreadyDone.includes(id));
+              return chain({ data: hits.map((id) => ({ gmail_message_id: id })), error: null });
+            }
+            if (table === "transactions") {
+              return chain({ data: FAKE_TXS.filter((tx) => ids.includes(tx.id)), error: null });
+            }
+            return chain({ data: [], error: null });
+          },
+          is:  (_c2: string, _v2: unknown) => chain({ data: [], error: null }),
+          not: (_c2: string, _op: string, _v2: unknown) => chain({ data: [], error: null }),
+          gte: (_c2: string, _v2: unknown) => ({
+            lte: (_c3: string, _v3: unknown) => chain({ data: FAKE_TXS, error: null }),
+          }),
+        }),
+        maybeSingle: () => chain({ data: null, error: null }),
+      }),
+      insert: (rows: unknown) => {
+        if (table === "email_receipts") {
+          const arr = Array.isArray(rows) ? rows : [rows];
+          const inserted = arr.map((r) => ({ ...r as object, id: `receipt-${++counter}` }));
+          inserted.forEach((r) => insertedReceipts.push(r));
+          return { select: () => chain({ data: inserted, error: null }) };
+        }
+        return chain({ data: null, error: null });
+      },
+      update: (patch: Record<string, unknown>) => ({
+        eq: (_c: string, id: unknown) => {
+          if (table === "email_receipts" && patch.transaction_id) {
+            updatedMatches.push({ id: id as string, transaction_id: patch.transaction_id as string });
+          }
+          return chain({ data: null, error: null });
+        },
+        in: () => chain({ data: null, error: null }),
+      }),
+      upsert: (rows: unknown, _opts?: unknown) => {
+        if (table === "email_receipts") {
+          const arr = Array.isArray(rows) ? rows : [rows];
+          const inserted = arr.map((r) => ({ ...r as object, id: `receipt-${++counter}` }));
+          inserted.forEach((r) => insertedReceipts.push(r));
+          return { select: (_cols?: string) => chain({ data: inserted, error: null }) };
+        }
+        return { select: () => chain({ data: null, error: null }) };
+      },
+    }),
+  };
+
+  return { db, insertedReceipts, updatedMatches };
+}
+
+// ── OpenAI response builder ────────────────────────────────────────────────────
+
+/** Sets up OpenAI mock to return the first matching parsed result based on body substring. */
+function setupParse(map: Array<[key: string, result: Record<string, unknown> | null]>) {
+  openaiMocks.setCreate(async (req: unknown) => {
+    const content = (req as { messages: Array<{ content: string }> }).messages[0]?.content ?? "";
+    let result: Record<string, unknown> | null = null;
+    for (const [key, val] of map) {
+      if (content.includes(key)) { result = val; break; }
+    }
+    return { choices: [{ message: { content: result == null ? '{"not_receipt":true}' : JSON.stringify(result) } }] };
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("Email receipt pipeline — full integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openaiMocks.resetCreate();
+    // Re-establish retry mock implementations wiped by vi.clearAllMocks()
+    (withRetry as ReturnType<typeof vi.fn>).mockImplementation((fn: () => unknown) => fn());
+    (mapWithConcurrency as ReturnType<typeof vi.fn>).mockImplementation(
+      async <T>(items: T[], fn: (item: T, index: number) => Promise<unknown>) => {
+        const results = [];
+        for (let i = 0; i < items.length; i++) results.push(await fn(items[i], i));
+        return results;
+      }
+    );
+  });
+
+  async function scan(...args: Parameters<Awaited<ReturnType<typeof getScanFn>>>) {
+    const fn = await getScanFn();
+    return fn(...args);
+  }
+
+  async function getScanFn() {
+    // Dynamic import so module re-evaluates with hoisted env + mocked OpenAI
+    const mod = await import("../receipt-parser");
+    return mod.scanGmailForReceipts;
+  }
+
+  // ── Pre-filters ──────────────────────────────────────────────────────────────
+
+  describe("Pre-filters", () => {
+    it("skips investment emails (questrade.com is excluded sender)", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-invest"]));
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.notReceipt).toBe(1);
+      expect(stats.parsed).toBe(0);
+      expect(insertedReceipts).toHaveLength(0);
+    });
+
+    it("skips Amazon shipped emails (only 'Ordered:' subject parsed)", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-shipped"]));
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.notReceipt).toBe(1);
+      expect(insertedReceipts).toHaveLength(0);
+    });
+
+    it("skips already-processed IDs when forceRescan=false", async () => {
+      const { db } = makeDb(["msg-sbux", "msg-spotify"]);
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+        gmail(["msg-sbux", "msg-spotify", "msg-amazon"])
+      );
+      setupParse([[ANCHORS.amazon, PARSED.amazon]]);
+
+      const stats = await scan("user_test", 30, false, false);
+
+      expect(stats.alreadyProcessed).toBe(2);
+      expect(stats.parsed).toBe(1); // only Amazon
+    });
+  });
+
+  // ── Parsing ──────────────────────────────────────────────────────────────────
+
+  describe("Parsing", () => {
+    it("parses Starbucks receipt — correct merchant, amount, date", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-sbux"]));
+      setupParse([[ANCHORS.starbucks, PARSED.starbucks]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.parsed).toBe(1);
+      expect(stats.insertErrors).toBe(0);
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "Starbucks", amount: 10.60, date: "2026-04-10" });
+    });
+
+    it("parses Amazon receipt — includes order_number", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-amazon"]));
+      setupParse([[ANCHORS.amazon, PARSED.amazon]]);
+
+      await scan("user_test", 30, false, true);
+
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "Amazon", amount: 30.50, order_number: "112-5551234-9876543" });
+    });
+
+    it("parses DoorDash delivery receipt", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-dd"]));
+      setupParse([[ANCHORS.doordash, PARSED.doordash]]);
+
+      await scan("user_test", 30, false, true);
+
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "DoorDash", amount: 33.29 });
+    });
+
+    it("parses Spotify subscription receipt", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-spotify"]));
+      setupParse([[ANCHORS.spotify, PARSED.spotify]]);
+
+      await scan("user_test", 30, false, true);
+
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "Spotify", amount: 11.99 });
+    });
+  });
+
+  // ── Matching ──────────────────────────────────────────────────────────────────
+
+  describe("Matching", () => {
+    it("matches Starbucks receipt to STARBUCKS transaction", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-sbux"]));
+      setupParse([[ANCHORS.starbucks, PARSED.starbucks]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-sbux")).toBe(true);
+    });
+
+    it("matches Amazon receipt to AMZN*MKTP US transaction (POS prefix stripped)", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-amazon"]));
+      setupParse([[ANCHORS.amazon, PARSED.amazon]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-amzn")).toBe(true);
+    });
+
+    it("matches Spotify receipt to SPOTIFY USA — NOT the $11.99 Hulu decoy on same day", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-spotify"]));
+      setupParse([[ANCHORS.spotify, PARSED.spotify]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-spotify")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-decoy")).toBe(false);
+    });
+
+    it("matches Mensho Tokyo SF receipt to SQ *MENSHO transaction (POS prefix stripping)", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-mensho"]));
+      setupParse([[ANCHORS.mensho, PARSED.mensho]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-mensho")).toBe(true);
+    });
+
+    it("batch: all 5 receipts parsed and each matched to the correct transaction", async () => {
+      const { db, insertedReceipts, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+        gmail(["msg-sbux", "msg-amazon", "msg-dd", "msg-spotify", "msg-mensho"])
+      );
+      setupParse([
+        [ANCHORS.starbucks, PARSED.starbucks],
+        [ANCHORS.amazon,    PARSED.amazon],
+        [ANCHORS.doordash,  PARSED.doordash],
+        [ANCHORS.spotify,   PARSED.spotify],
+        [ANCHORS.mensho,    PARSED.mensho],
+      ]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.parsed).toBe(5);
+      expect(stats.insertErrors).toBe(0);
+      expect(insertedReceipts).toHaveLength(5);
+      expect(stats.matched).toBe(5);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-sbux")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-amzn")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-dd")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-spotify")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-mensho")).toBe(true);
+    });
+  });
+
+  // ── Scan stats ────────────────────────────────────────────────────────────────
+
+  describe("Scan stats", () => {
+    it("counts notReceipt + parsed correctly in a mixed batch", async () => {
+      const { db } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+        gmail(["msg-sbux", "msg-invest", "msg-shipped"])
+      );
+      setupParse([[ANCHORS.starbucks, PARSED.starbucks]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.emailsFetched).toBe(3);
+      expect(stats.parsed).toBe(1);     // Starbucks only
+      expect(stats.notReceipt).toBe(2); // investment + shipped
+    });
+  });
+});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -113,14 +113,27 @@ export const GMAIL = {
 } as const;
 
 export const RECEIPT_MATCH = {
-  AMOUNT_TOLERANCE_DOLLARS: 5,
-  AMOUNT_TOLERANCE_PERCENT: 0.20,
-  DATE_WINDOW_DAYS: 7,
+  // Amount tolerance when merchant name matches (tiered: min of dollars vs percent)
+  AMOUNT_TOLERANCE_DOLLARS: 5.0,
+  AMOUNT_TOLERANCE_PERCENT: 0.10,
+  // Exact tolerance for Strategy 3 (no merchant signal)
+  AMOUNT_TOLERANCE_EXACT: 0.01,
+  // Asymmetric date windows — receipt date is order date, bank posts later
+  WINDOW_BEFORE_DAYS: 3,
+  WINDOW_AFTER_DAYS: 10,
+  TIGHT_WINDOW_BEFORE_DAYS: 1,
+  TIGHT_WINDOW_AFTER_DAYS: 4,
   MIN_KEYWORD_LENGTH: 3,
+  MAX_KEYWORDS: 7,
   STOP_WORDS: new Set([
     "the", "and", "for", "inc", "llc", "ltd", "com", "www", "online",
     "payment", "pay", "purchase", "store", "shop", "receipt", "order",
     "confirmation", "your", "thank", "you",
+    "service", "services", "app", "group", "co", "corp",
+    "new", "usa", "us", "get", "my",
+    "restaurant", "bar", "grill", "cafe", "kitchen", "coffee",
+    "delivery", "shipping", "express",
+    "airlines", "airline", "air", "travel",
   ]),
 } as const;
 

--- a/lib/paypal-auth.ts
+++ b/lib/paypal-auth.ts
@@ -249,14 +249,19 @@ export async function removePayPalConnection(clerkUserId: string) {
 
   const txIds = (paypalTxs ?? []).map(t => t.id);
 
-  // Clean up subscription_transactions references before deleting transactions
+  // Clear FK references to PayPal transactions in parallel
   if (txIds.length > 0) {
-    await db.from("subscription_transactions").delete().in("transaction_id", txIds);
-    await clearEmailReceiptLinksForTransactionIds(db, clerkUserId, txIds);
+    await Promise.all([
+      db.from("subscription_transactions").delete().in("transaction_id", txIds),
+      clearEmailReceiptLinksForTransactionIds(db, clerkUserId, txIds),
+    ]);
   }
 
-  await db.from("paypal_connections").delete().eq("clerk_user_id", clerkUserId);
-  await db.from("transactions").delete().eq("clerk_user_id", clerkUserId).eq("source", "paypal");
+  // Delete connection record and PayPal transactions in parallel
+  await Promise.all([
+    db.from("paypal_connections").delete().eq("clerk_user_id", clerkUserId),
+    db.from("transactions").delete().eq("clerk_user_id", clerkUserId).eq("source", "paypal"),
+  ]);
 }
 
 export { PAYPAL_BASE };

--- a/lib/receipt-matcher.ts
+++ b/lib/receipt-matcher.ts
@@ -1,8 +1,17 @@
 import { getSupabase } from "./supabase";
 import { RECEIPT_MATCH } from "./config";
 
+// POS processor prefixes that appear in Plaid transaction names but not email receipts.
+// Strip these before matching so "SQ *MENSHO" matches "Mensho Tokyo SF".
+const POS_PREFIX_RE = /^(sq\s*\*|tst\*|tst\s+|sp\s*\*|pp\s*\*|pp\s+|amzn\s*\*|paypal\s*\*|paypal\s+|checkcard\s+|pos\s+|purchase\s+|ach\s+|dda\s+|applecard\s+gs\s+bank|google\s*\*)\s*/i;
+
 export function normalizeMerchant(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/\s+/g, " ").trim();
+  return s
+    .replace(POS_PREFIX_RE, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function sanitizeForIlike(s: string): string {
@@ -20,7 +29,7 @@ const MERCHANT_ALIASES: Record<string, string[]> = {
   costco: ["costco", "costco whse"],
   airbnb: ["airbnb", "air bnb"],
   starbucks: ["starbucks", "sbux"],
-  mcdonalds: ["mcdonalds", "mcdonald"],
+  mcdonalds: ["mcdonalds", "mcdonald", "mcd"],
   apple: ["apple", "apple com bill", "apple com"],
   spotify: ["spotify"],
   netflix: ["netflix"],
@@ -31,21 +40,69 @@ const MERCHANT_ALIASES: Record<string, string[]> = {
   clipper: ["clipper", "clipper card", "bay area toll"],
   frontier: ["frontier", "frontier airlines"],
   wise: ["wise", "transferwise"],
+  chipotle: ["chipotle", "chipotle mexican"],
+  traderjoes: ["trader joes", "trader joe"],
+  wholefoods: ["whole foods", "wholefoods", "wfm"],
+  sephora: ["sephora"],
+  nike: ["nike"],
+  homedepot: ["home depot", "the home depot"],
+  lowes: ["lowes", "lowe s"],
+  bestbuy: ["best buy", "bestbuy"],
+  chewy: ["chewy"],
+  etsy: ["etsy"],
+  deltaairlines: ["delta", "delta air", "delta airlines"],
+  unitedairlines: ["united", "united airlines", "united air"],
+  southwest: ["southwest", "southwest airlines"],
+  hulu: ["hulu"],
+  disney: ["disney", "disney plus", "disneyplus"],
+  github: ["github"],
+  openai: ["openai", "openai chatgpt"],
 };
 
-function resolveAliases(merchant: string): string[] {
+/**
+ * Returns the canonical alias group key(s) that merchant belongs to.
+ * Used ONLY for group-membership checks (same group = same merchant).
+ * Intentionally excludes sub-tokens to prevent cross-group collisions
+ * (e.g. "airlines" appearing in both Delta and United).
+ */
+function resolveAliasGroups(merchant: string): string[] {
+  const norm = normalizeMerchant(merchant);
+  const groups: string[] = [];
+  for (const [canonical, aliases] of Object.entries(MERCHANT_ALIASES)) {
+    if (aliases.some((a) => norm.includes(a)) || norm.includes(canonical)) {
+      groups.push(canonical);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Returns all alias tokens (canonical key + sub-tokens from alias strings)
+ * for a merchant. Used for keyword extraction and word-boundary matching.
+ * Stop words are filtered to avoid generic tokens (e.g. "airlines") causing
+ * cross-group false positives.
+ */
+function resolveAliasKeywords(merchant: string): string[] {
   const norm = normalizeMerchant(merchant);
   const extra: string[] = [];
   for (const [canonical, aliases] of Object.entries(MERCHANT_ALIASES)) {
     if (aliases.some((a) => norm.includes(a)) || norm.includes(canonical)) {
-      extra.push(canonical);
+      if (!extra.includes(canonical)) extra.push(canonical);
       for (const a of aliases) {
-        const kw = a.split(" ")[0];
-        if (kw.length >= 3 && !extra.includes(kw)) extra.push(kw);
+        for (const kw of a.split(" ").filter(
+          (t) => t.length >= 3 && !RECEIPT_MATCH.STOP_WORDS.has(t)
+        )) {
+          if (!extra.includes(kw)) extra.push(kw);
+        }
       }
     }
   }
   return extra;
+}
+
+/** @deprecated Use resolveAliasGroups or resolveAliasKeywords */
+function resolveAliases(merchant: string): string[] {
+  return resolveAliasKeywords(merchant);
 }
 
 export function extractKeywords(merchant: string): string[] {
@@ -58,7 +115,7 @@ export function extractKeywords(merchant: string): string[] {
     .map(sanitizeForIlike)
     .filter((w) => w.length > 0);
 
-  const aliasKeywords = resolveAliases(merchant)
+  const aliasKeywords = resolveAliasKeywords(merchant)
     .map(sanitizeForIlike)
     .filter((w) => w.length > 0);
 
@@ -70,7 +127,7 @@ export function extractKeywords(merchant: string): string[] {
       result.push(w);
     }
   }
-  return result.slice(0, 5);
+  return result.slice(0, RECEIPT_MATCH.MAX_KEYWORDS);
 }
 
 export function merchantsMatch(receiptMerchant: string, txMerchant: string): boolean {
@@ -86,21 +143,47 @@ export function merchantsMatch(receiptMerchant: string, txMerchant: string): boo
   const bKeywords = b.split(" ").filter((w) => w.length >= 3);
   if (bKeywords.some((kw) => a.includes(kw))) return true;
 
-  const aAliases = resolveAliases(receiptMerchant);
-  const bAliases = resolveAliases(txMerchant);
-  if (aAliases.length > 0 && bAliases.length > 0) {
-    if (aAliases.some((aa) => bAliases.includes(aa))) return true;
+  // Group check: same canonical alias group = same merchant
+  const aGroups = resolveAliasGroups(receiptMerchant);
+  const bGroups = resolveAliasGroups(txMerchant);
+  if (aGroups.length > 0 && bGroups.length > 0) {
+    if (aGroups.some((g) => bGroups.includes(g))) return true;
   }
-  if (aAliases.some((aa) => b.includes(aa))) return true;
-  if (bAliases.some((ba) => a.includes(ba))) return true;
+
+  // Keyword check: alias tokens from one side appear as whole words in the other's
+  // normalized name. Use word-token matching (not substring) to prevent e.g.
+  // "delta" alias token "air" matching inside "united airlines".
+  const aWords = new Set(a.split(" "));
+  const bWords = new Set(b.split(" "));
+  const aKeywordAliases = resolveAliasKeywords(receiptMerchant);
+  const bKeywordAliases = resolveAliasKeywords(txMerchant);
+  if (aKeywordAliases.some((kw) => bWords.has(kw))) return true;
+  if (bKeywordAliases.some((kw) => aWords.has(kw))) return true;
 
   return false;
 }
 
-function amountWithinTolerance(receiptAmount: number, txAmount: number): boolean {
-  // Exact match only — $0.01 rounding buffer for floating-point representation.
-  // Loose dollar/percent tolerances caused too many false matches on small amounts.
-  return Math.abs(txAmount - receiptAmount) <= 0.01;
+/**
+ * When merchantMatched=true (Strategies 1 & 2), allow up to ±$5 or ±10% of
+ * the receipt amount, whichever is smaller. This covers tips, rounding, and
+ * tax discrepancies while avoiding false positives on large amounts.
+ * When merchantMatched=false (Strategy 3 — no merchant validation), require
+ * exact match ($0.01) to compensate for the lack of merchant signal.
+ */
+function amountWithinTolerance(
+  receiptAmount: number,
+  txAmount: number,
+  merchantMatched = false
+): boolean {
+  const diff = Math.abs(txAmount - receiptAmount);
+  if (merchantMatched) {
+    const tolerance = Math.min(
+      RECEIPT_MATCH.AMOUNT_TOLERANCE_DOLLARS,
+      receiptAmount * RECEIPT_MATCH.AMOUNT_TOLERANCE_PERCENT
+    );
+    return diff <= Math.max(tolerance, RECEIPT_MATCH.AMOUNT_TOLERANCE_EXACT);
+  }
+  return diff <= RECEIPT_MATCH.AMOUNT_TOLERANCE_EXACT;
 }
 
 /**
@@ -110,10 +193,10 @@ function amountWithinTolerance(receiptAmount: number, txAmount: number): boolean
  */
 function knownMerchantsConflict(m1: string, m2: string): boolean {
   if (!m1 || !m2) return false;
-  const a1 = resolveAliases(m1);
-  const a2 = resolveAliases(m2);
-  // Both are recognised merchants and share no alias group → definitively different
-  return a1.length > 0 && a2.length > 0 && !a1.some((a) => a2.includes(a));
+  const g1 = resolveAliasGroups(m1);
+  const g2 = resolveAliasGroups(m2);
+  // Both are recognised merchants and share no canonical group → definitively different
+  return g1.length > 0 && g2.length > 0 && !g1.some((g) => g2.includes(g));
 }
 
 export function scoreCandidates(
@@ -125,25 +208,32 @@ export function scoreCandidates(
   const scored = candidates
     .map((tx) => {
       const txAmount = Math.abs(Number(tx.amount));
-      const amountDiff = Math.abs(txAmount - receiptAmount);
+      const txMerch = tx.normalized_merchant || tx.merchant_name || "";
+      // merchantMatched=true only when there is a real merchant signal on both sides.
+      // Missing merchant name → false (tight tolerance), not true (loose tolerance).
+      const merchantMatched = Boolean(
+        receiptMerchant && txMerch && merchantsMatch(receiptMerchant, txMerch)
+      );
       return {
         id: tx.id,
-        amountDiff,
+        txAmount,
+        amountDiff: Math.abs(txAmount - receiptAmount),
         dateDiff: receiptDate
           ? Math.abs(new Date(tx.date).getTime() - new Date(receiptDate).getTime())
           : 0,
         normalized_merchant: tx.normalized_merchant,
         merchant_name: tx.merchant_name,
+        merchantMatched,
       };
     })
     .filter((s) => {
-      if (!amountWithinTolerance(receiptAmount, receiptAmount + s.amountDiff)) return false;
-
+      // Reject if amount is outside tolerance (tiered by merchant match confidence)
+      if (!amountWithinTolerance(receiptAmount, s.txAmount, s.merchantMatched)) return false;
+      // Reject if a receipt merchant was provided but this tx doesn't match
       if (receiptMerchant) {
         const txMerch = s.normalized_merchant || s.merchant_name || "";
         if (txMerch && !merchantsMatch(receiptMerchant, txMerch)) return false;
       }
-
       return true;
     })
     .sort((a, b) => a.amountDiff - b.amountDiff || a.dateDiff - b.dateDiff);
@@ -187,16 +277,20 @@ export async function matchReceiptsToTransactions(
     (alreadyLinked ?? []).map((r) => r.transaction_id as string).filter(Boolean)
   );
 
-  const windowDays = RECEIPT_MATCH.DATE_WINDOW_DAYS;
+  // Asymmetric window: receipt date is the order date; bank transactions typically
+  // post 1-3 days later. Look back a few days (pre-auth/same-day charges) and
+  // forward more days (delayed posting, pending → posted transitions).
+  const WINDOW_BEFORE_DAYS = RECEIPT_MATCH.WINDOW_BEFORE_DAYS;
+  const WINDOW_AFTER_DAYS = RECEIPT_MATCH.WINDOW_AFTER_DAYS;
 
-  // Collect the overall date range covering ALL receipts (+ window on each side)
+  // Collect the overall date range covering ALL receipts
   let globalMinDate: Date | null = null;
   let globalMaxDate: Date | null = null;
   for (const receipt of receipts) {
     if (!receipt.date) continue;
     const d = new Date(receipt.date);
-    const lo = new Date(d); lo.setDate(lo.getDate() - windowDays);
-    const hi = new Date(d); hi.setDate(hi.getDate() + windowDays);
+    const lo = new Date(d); lo.setDate(lo.getDate() - WINDOW_BEFORE_DAYS);
+    const hi = new Date(d); hi.setDate(hi.getDate() + WINDOW_AFTER_DAYS);
     if (!globalMinDate || lo < globalMinDate) globalMinDate = lo;
     if (!globalMaxDate || hi > globalMaxDate) globalMaxDate = hi;
   }
@@ -229,13 +323,14 @@ export async function matchReceiptsToTransactions(
     let tightEnd: string | undefined;
     if (receiptDate) {
       const dateObj = new Date(receiptDate);
-      const start = new Date(dateObj); start.setDate(start.getDate() - windowDays);
-      const end = new Date(dateObj); end.setDate(end.getDate() + windowDays);
+      const start = new Date(dateObj); start.setDate(start.getDate() - WINDOW_BEFORE_DAYS);
+      const end = new Date(dateObj); end.setDate(end.getDate() + WINDOW_AFTER_DAYS);
       dateStart = start.toISOString().split("T")[0];
       dateEnd = end.toISOString().split("T")[0];
 
-      const ts = new Date(dateObj); ts.setDate(ts.getDate() - 3);
-      const te = new Date(dateObj); te.setDate(te.getDate() + 3);
+      // Tight window for Strategy 3: same asymmetry but narrower
+      const ts = new Date(dateObj); ts.setDate(ts.getDate() - RECEIPT_MATCH.TIGHT_WINDOW_BEFORE_DAYS);
+      const te = new Date(dateObj); te.setDate(te.getDate() + RECEIPT_MATCH.TIGHT_WINDOW_AFTER_DAYS);
       tightStart = ts.toISOString().split("T")[0];
       tightEnd = te.toISOString().split("T")[0];
     }
@@ -292,7 +387,7 @@ export async function matchReceiptsToTransactions(
             txAmount,
           };
         })
-        .filter((s) => amountWithinTolerance(receiptAmount, receiptAmount + s.amountDiff) && isFinite(s.dateDiff))
+        .filter((s) => amountWithinTolerance(receiptAmount, receiptAmount + s.amountDiff, true) && isFinite(s.dateDiff))
         .sort((a, b) => a.amountDiff - b.amountDiff || a.dateDiff - b.dateDiff);
 
       if (scored.length > 0) {
@@ -321,7 +416,7 @@ export async function matchReceiptsToTransactions(
             dateDiff: Math.abs(new Date(tx.date).getTime() - new Date(receiptDate).getTime()),
           };
         })
-        .filter((s) => s.amountDiff <= 0.01)
+        .filter((s) => amountWithinTolerance(receiptAmount, receiptAmount + s.amountDiff, false))
         .sort((a, b) => a.amountDiff - b.amountDiff || a.dateDiff - b.dateDiff);
 
       if (scored.length > 0) {
@@ -424,7 +519,7 @@ export async function auditAndRematchAllReceipts(
       // But if merchants are known-conflicting aliases (e.g. Airbnb vs Clipper),
       // clear it regardless of how close the amounts are.
       const nameOk = merchantsMatch(receipt.merchant, txMerchant);
-      const tightAmountOk = Math.abs(txAmount - rcptAmount) <= 0.01;
+      const tightAmountOk = amountWithinTolerance(rcptAmount, txAmount, false);
       const aliasConflict = knownMerchantsConflict(receipt.merchant, txMerchant);
       if (!nameOk && (!tightAmountOk || aliasConflict)) {
         toClear.push(receipt.id as string);

--- a/lib/receipt-parser.ts
+++ b/lib/receipt-parser.ts
@@ -364,20 +364,20 @@ export async function scanGmailForReceipts(
   let alreadyProcessed = 0;
 
   if (!forceRescan) {
-    const { data: existing } = await db
-      .from("email_receipts")
-      .select("gmail_message_id")
-      .eq("clerk_user_id", clerkUserId)
-      .in("gmail_message_id", messageIds);
+    const [{ data: existing }, { data: logged }] = await Promise.all([
+      db
+        .from("email_receipts")
+        .select("gmail_message_id")
+        .eq("clerk_user_id", clerkUserId)
+        .in("gmail_message_id", messageIds),
+      db
+        .from("gmail_scan_log")
+        .select("gmail_message_id")
+        .eq("clerk_user_id", clerkUserId)
+        .in("gmail_message_id", messageIds),
+    ]);
 
     const processedIds = new Set((existing || []).map((r: { gmail_message_id: string }) => r.gmail_message_id));
-
-    // Also check scan log for previously attempted (non-receipt, errors, etc.)
-    const { data: logged } = await db
-      .from("gmail_scan_log")
-      .select("gmail_message_id")
-      .eq("clerk_user_id", clerkUserId)
-      .in("gmail_message_id", messageIds);
     const loggedIds = new Set((logged || []).map((r: { gmail_message_id: string }) => r.gmail_message_id));
 
     newMessageIds = messageIds.filter((id) => !processedIds.has(id) && !loggedIds.has(id));
@@ -539,16 +539,16 @@ export async function scanGmailForReceipts(
     }
   }
 
-  // Match receipts to transactions
-  let matched = 0;
-  if (insertedReceiptIds.length > 0) {
-    matched = await matchReceiptsToTransactions(clerkUserId, insertedReceiptIds);
-  }
-
-  // Update last scan timestamp
-  await db.from("gmail_connections")
-    .update({ last_scan_at: new Date().toISOString() })
-    .eq("clerk_user_id", clerkUserId);
+  // Match receipts to transactions and update scan timestamp in parallel
+  const [matchedCount] = await Promise.all([
+    insertedReceiptIds.length > 0
+      ? matchReceiptsToTransactions(clerkUserId, insertedReceiptIds)
+      : Promise.resolve(0),
+    db.from("gmail_connections")
+      .update({ last_scan_at: new Date().toISOString() })
+      .eq("clerk_user_id", clerkUserId),
+  ]);
+  const matched = matchedCount;
 
   // Optionally return the inserted receipts
   let receipts: unknown[] = [];

--- a/supabase/migrations/20260414_perf_indexes_v6.sql
+++ b/supabase/migrations/20260414_perf_indexes_v6.sql
@@ -1,0 +1,32 @@
+-- Performance indexes v6: Stripe, Splitwise, split-transaction and job queue hot paths
+-- Run in Supabase SQL editor. All use CONCURRENTLY to avoid locking.
+
+-- Stripe Connected Account lookups: connect/status, create-account, receiver-status, create-payment-intent
+CREATE INDEX CONCURRENTLY IF NOT EXISTS stripe_connected_accounts_clerk_user_idx
+  ON stripe_connected_accounts (clerk_user_id);
+
+-- Splitwise token lookups: splitwise/status, splitwise/official-balances, splitwise/import
+CREATE INDEX CONCURRENTLY IF NOT EXISTS splitwise_tokens_clerk_user_idx
+  ON splitwise_tokens (clerk_user_id);
+
+-- Split-transaction duplicate check: WHERE group_id = ? AND transaction_id = ?
+CREATE INDEX CONCURRENTLY IF NOT EXISTS split_transactions_group_tx_idx
+  ON split_transactions (group_id, transaction_id);
+
+-- Job queue type+status filter: background sync workers, reauth checks
+CREATE INDEX CONCURRENTLY IF NOT EXISTS job_queue_type_status_idx
+  ON job_queue (type, status)
+  WHERE status IN ('pending', 'processing');
+
+-- Subscriptions active lookup: chat context, insights, subscription detect
+CREATE INDEX CONCURRENTLY IF NOT EXISTS subscriptions_user_status_idx
+  ON subscriptions (clerk_user_id, status)
+  WHERE status = 'active';
+
+-- Gmail scan log: receipt parser skip-duplicates check (clerk_user_id, gmail_message_id)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gmail_scan_log_user_msg_idx
+  ON gmail_scan_log (clerk_user_id, gmail_message_id);
+
+-- Accounts table: user account listing for Plaid accounts route
+CREATE INDEX CONCURRENTLY IF NOT EXISTS accounts_clerk_user_idx
+  ON accounts (clerk_user_id);


### PR DESCRIPTION
## Summary

- **POS prefix stripping** — `normalizeMerchant` now strips `SQ*`, `TST*`, `AMZN*`, `PP*`, `SP*`, `Google*`, `PayPal`, `CHECKCARD`, `POS` so `SQ *MENSHO` correctly matches `Mensho Tokyo SF`
- **Expanded merchant aliases** — 16+ new entries (Chipotle, Trader Joe's, Whole Foods, Delta, United, Southwest, Hulu, Disney+, GitHub, OpenAI, etc.) with word-boundary matching fix so Delta/United no longer cross-match
- **Tiered amount tolerance** — merchant-matched uses `min($5, 10%)`, no-merchant uses exact `$0.01` to prevent false positives
- **Asymmetric date window** — `-3/+10` days (receipt = order date, bank posts later) instead of symmetric `±7`

## Tests

- `lib/__tests__/receipt-matcher.test.ts` — 68 unit tests (normalizeMerchant, merchantsMatch, extractKeywords, scoreCandidates)
- `lib/__tests__/receipt-pipeline.test.ts` — 13 integration tests with fake receipt emails, mocked Gmail/OpenAI/Supabase, verifying full parse→match pipeline including Spotify vs Hulu decoy avoidance and SQ*MENSHO POS prefix stripping

## Test plan

- [x] `npm run test lib/__tests__/receipt-matcher.test.ts` — 68/68 pass
- [x] `npm run test lib/__tests__/receipt-pipeline.test.ts` — 13/13 pass
- [ ] Verify on prod: trigger a Gmail scan and check match rate improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)