### PR TITLE
feat: improve email receipt matching quality + integration tests

### DIFF
--- a/app/api/debug/receipt-match-verify/route.ts
+++ b/app/api/debug/receipt-match-verify/route.ts
@@ -269,8 +269,6 @@ export async function GET() {
     } | null;
   }> = [];
 
-  const windowDays = RECEIPT_MATCH.DATE_WINDOW_DAYS;
-
   for (const receipt of unmatchedReceiptRows) {
     if (!receipt.merchant || !receipt.amount) continue;
 
@@ -282,9 +280,9 @@ export async function GET() {
     if (receipt.date) {
       const dateObj = new Date(receipt.date);
       const start = new Date(dateObj);
-      start.setDate(start.getDate() - windowDays);
+      start.setDate(start.getDate() - RECEIPT_MATCH.WINDOW_BEFORE_DAYS);
       const end = new Date(dateObj);
-      end.setDate(end.getDate() + windowDays);
+      end.setDate(end.getDate() + RECEIPT_MATCH.WINDOW_AFTER_DAYS);
       dateStart = start.toISOString().split("T")[0];
       dateEnd = end.toISOString().split("T")[0];
     }

--- a/lib/__tests__/receipt-matcher.test.ts
+++ b/lib/__tests__/receipt-matcher.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for lib/receipt-matcher.ts
+ *
+ * Covers normalizeMerchant, merchantsMatch, extractKeywords, scoreCandidates,
+ * and realistic receipt→transaction match scenarios.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  normalizeMerchant,
+  merchantsMatch,
+  extractKeywords,
+  scoreCandidates,
+} from "../receipt-matcher";
+
+// ─── normalizeMerchant ────────────────────────────────────────────────────────
+
+describe("normalizeMerchant", () => {
+  describe("POS prefix stripping", () => {
+    it("strips SQ * (Square)", () => {
+      expect(normalizeMerchant("SQ *MENSHO")).toBe("mensho");
+      expect(normalizeMerchant("SQ *Blue Bottle Coffee")).toBe("blue bottle coffee");
+    });
+    it("strips SQ* without space", () => {
+      expect(normalizeMerchant("SQ*TARTINE")).toBe("tartine");
+    });
+    it("strips TST* (Toast)", () => {
+      expect(normalizeMerchant("TST*TACOLICIOUS")).toBe("tacolicious");
+    });
+    it("strips TST (space) prefix", () => {
+      expect(normalizeMerchant("TST DUMPLING TIME")).toBe("dumpling time");
+    });
+    it("strips SP * (Shopify)", () => {
+      expect(normalizeMerchant("SP *Allbirds")).toBe("allbirds");
+    });
+    it("strips PP * (PayPal)", () => {
+      expect(normalizeMerchant("PP *STUBHUB")).toBe("stubhub");
+    });
+    it("strips AMZN* prefix", () => {
+      expect(normalizeMerchant("AMZN*MKTP US")).toBe("mktp us");
+    });
+    it("strips PayPal (space) prefix", () => {
+      expect(normalizeMerchant("PayPal EBAY")).toBe("ebay");
+    });
+    it("strips Google* prefix", () => {
+      expect(normalizeMerchant("Google *YouTube Premium")).toBe("youtube premium");
+    });
+    it("strips CHECKCARD prefix", () => {
+      expect(normalizeMerchant("CHECKCARD 0412 COSTCO WHSE")).toBe("0412 costco whse");
+    });
+    it("strips POS prefix", () => {
+      expect(normalizeMerchant("POS WALMART SUPERCENTER")).toBe("walmart supercenter");
+    });
+    it("is case-insensitive for prefix matching", () => {
+      expect(normalizeMerchant("sq *Blue Bottle")).toBe("blue bottle");
+    });
+  });
+
+  describe("character normalization", () => {
+    it("lowercases result", () => {
+      expect(normalizeMerchant("STARBUCKS")).toBe("starbucks");
+    });
+    it("strips apostrophes", () => {
+      expect(normalizeMerchant("McDonald's")).toBe("mcdonalds");
+      expect(normalizeMerchant("Trader Joe's")).toBe("trader joes");
+      expect(normalizeMerchant("Lowe's")).toBe("lowes");
+    });
+    it("collapses multiple spaces", () => {
+      expect(normalizeMerchant("HOME   DEPOT")).toBe("home depot");
+    });
+    it("trims whitespace", () => {
+      expect(normalizeMerchant("  Nike  ")).toBe("nike");
+    });
+  });
+
+  describe("numeric merchants", () => {
+    it("preserves numbers", () => {
+      expect(normalizeMerchant("7-Eleven")).toBe("7eleven");
+      expect(normalizeMerchant("76 Gas")).toBe("76 gas");
+    });
+    it("preserves numbers after POS stripping", () => {
+      expect(normalizeMerchant("SQ *7-Eleven")).toBe("7eleven");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      expect(normalizeMerchant("")).toBe("");
+    });
+    it("handles all-punctuation string", () => {
+      expect(normalizeMerchant("***---***")).toBe("");
+    });
+  });
+});
+
+// ─── merchantsMatch ───────────────────────────────────────────────────────────
+
+describe("merchantsMatch", () => {
+  describe("substring containment", () => {
+    it("matches when one normalized form contains the other", () => {
+      expect(merchantsMatch("Starbucks", "STARBUCKS COFFEE 1234")).toBe(true);
+    });
+    it("returns false for unrelated merchants", () => {
+      expect(merchantsMatch("Shell", "Sheraton Hotel")).toBe(false);
+    });
+    it("returns false when either input is empty", () => {
+      expect(merchantsMatch("", "Starbucks")).toBe(false);
+      expect(merchantsMatch("Starbucks", "")).toBe(false);
+    });
+  });
+
+  describe("keyword matching", () => {
+    it("matches on shared keyword >= 3 chars", () => {
+      expect(merchantsMatch("Chipotle Mexican Grill", "CHIPOTLE 2341")).toBe(true);
+      expect(merchantsMatch("Best Buy", "BEST BUY #432")).toBe(true);
+    });
+  });
+
+  describe("POS prefix stripping", () => {
+    it("matches SQ * prefixed tx name against plain receipt merchant", () => {
+      expect(merchantsMatch("Mensho Tokyo SF", "SQ *MENSHO")).toBe(true);
+    });
+    it("matches TST* prefixed tx name against plain receipt merchant", () => {
+      expect(merchantsMatch("Tacolicious", "TST*TACOLICIOUS")).toBe(true);
+    });
+    it("matches AMZN* tx against Amazon receipt", () => {
+      expect(merchantsMatch("Amazon", "AMZN*MKTP US")).toBe(true);
+    });
+  });
+
+  describe("alias-based matching", () => {
+    it("matches Uber variants", () => {
+      expect(merchantsMatch("Uber", "UBER TRIP")).toBe(true);
+      expect(merchantsMatch("Uber Eats", "UBER EATS")).toBe(true);
+    });
+    it("matches Amazon variants", () => {
+      expect(merchantsMatch("Amazon", "AMZN MKTP")).toBe(true);
+    });
+    it("matches Trader Joe's variants", () => {
+      expect(merchantsMatch("Trader Joe's", "TRADER JOE")).toBe(true);
+    });
+    it("matches Whole Foods variants", () => {
+      expect(merchantsMatch("Whole Foods Market", "WHOLEFDS SFO")).toBe(true);
+      expect(merchantsMatch("WFM", "Whole Foods")).toBe(true);
+    });
+    it("matches Walmart variants", () => {
+      expect(merchantsMatch("Walmart", "WAL-MART")).toBe(true);
+      expect(merchantsMatch("Walmart.com", "WM SUPERCENTER #1234")).toBe(true);
+    });
+    it("matches Home Depot variants", () => {
+      expect(merchantsMatch("Home Depot", "THE HOME DEPOT #0604")).toBe(true);
+    });
+    it("matches Delta Airlines variants", () => {
+      expect(merchantsMatch("Delta Airlines", "DELTA AIR")).toBe(true);
+    });
+    it("matches DoorDash variants", () => {
+      expect(merchantsMatch("DoorDash", "DD DOORDASH")).toBe(true);
+    });
+    it("matches Grubhub / Seamless as same group", () => {
+      expect(merchantsMatch("Grubhub", "SEAMLESS")).toBe(true);
+      expect(merchantsMatch("Seamless", "Grubhub")).toBe(true);
+    });
+    it("matches OpenAI / ChatGPT", () => {
+      expect(merchantsMatch("OpenAI", "OPENAI CHATGPT")).toBe(true);
+    });
+    it("does NOT match different alias groups", () => {
+      expect(merchantsMatch("Airbnb", "Clipper")).toBe(false);
+      expect(merchantsMatch("Netflix", "Spotify")).toBe(false);
+      expect(merchantsMatch("Lyft", "Uber")).toBe(false);
+      expect(merchantsMatch("Delta", "United Airlines")).toBe(false);
+    });
+  });
+
+  describe("short merchant names", () => {
+    it("matches CVS via substring", () => {
+      expect(merchantsMatch("CVS", "CVS PHARMACY #4532")).toBe(true);
+    });
+    it("matches HEB via substring", () => {
+      expect(merchantsMatch("HEB", "HEB GAS #0012")).toBe(true);
+    });
+  });
+
+  describe("numeric merchants", () => {
+    it("matches 7-Eleven variants", () => {
+      expect(merchantsMatch("7-Eleven", "7-ELEVEN 34567")).toBe(true);
+    });
+  });
+});
+
+// ─── extractKeywords ──────────────────────────────────────────────────────────
+
+describe("extractKeywords", () => {
+  it("filters stop words", () => {
+    const kws = extractKeywords("The Store Online");
+    expect(kws).not.toContain("the");
+    expect(kws).not.toContain("store");
+    expect(kws).not.toContain("online");
+  });
+
+  it("filters tokens shorter than MIN_KEYWORD_LENGTH", () => {
+    const kws = extractKeywords("BP Gas");
+    expect(kws).not.toContain("bp");
+    expect(kws).toContain("gas");
+  });
+
+  it("deduplicates keywords", () => {
+    const kws = extractKeywords("Amazon Amazon");
+    expect(kws.filter((k) => k === "amazon").length).toBe(1);
+  });
+
+  it("injects alias canonical keys", () => {
+    expect(extractKeywords("Amazon")).toContain("amazon");
+    expect(extractKeywords("Uber Eats")).toContain("uber");
+  });
+
+  it("injects all alias tokens, not just first word", () => {
+    // "trader joe" alias → both "trader" and "joe" should be available
+    const kws = extractKeywords("Trader Joe's");
+    expect(kws).toContain("trader");
+    expect(kws).toContain("joe");
+  });
+
+  it("caps result at MAX_KEYWORDS (7)", () => {
+    const kws = extractKeywords("Starbucks Coffee Roasters International Premium Blend Reserve");
+    expect(kws.length).toBeLessThanOrEqual(7);
+  });
+
+  it("handles POS-prefixed merchant name", () => {
+    const kws = extractKeywords("SQ *Blue Bottle Coffee");
+    expect(kws).toContain("blue");
+    expect(kws).toContain("bottle");
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(extractKeywords("")).toEqual([]);
+  });
+
+  it("strips ILIKE-unsafe characters from keywords", () => {
+    for (const kw of extractKeywords("H&M Store 50% off")) {
+      expect(kw).not.toMatch(/[%_\\]/);
+    }
+  });
+});
+
+// ─── scoreCandidates ─────────────────────────────────────────────────────────
+
+describe("scoreCandidates", () => {
+  const date = "2025-03-15";
+
+  function tx(id: string, amount: number, d: string, merchant: string) {
+    return { id, amount, date: d, normalized_merchant: merchant, merchant_name: merchant };
+  }
+
+  describe("tiered tolerance — merchant matched", () => {
+    it("accepts tx within $5 absolute tolerance", () => {
+      // $25 receipt, $28 tx — $3 diff < min($5, 10%*$25=$2.50) → $2.50... wait, $3 > $2.50
+      // Actually min($5, $2.50) = $2.50, so $3 diff is rejected. Let's use $27 ($2 diff < $2.50).
+      expect(scoreCandidates([tx("t1", 27.00, date, "starbucks")], 25.00, date, "Starbucks")).toBe("t1");
+    });
+
+    it("accepts tx within 10% tolerance for larger amounts", () => {
+      // $100 receipt, $108 tx — diff $8 < min($5, 10%*$100=$10) = $5 → rejects at $8
+      // Use $104 (diff $4 < $5)
+      expect(scoreCandidates([tx("t1", 104.00, date, "amazon")], 100.00, date, "Amazon")).toBe("t1");
+    });
+
+    it("rejects tx outside min($5, 10%) tolerance", () => {
+      // $100 receipt, $115 tx — diff $15 > $5
+      expect(scoreCandidates([tx("t1", 115.00, date, "amazon")], 100.00, date, "Amazon")).toBeNull();
+    });
+  });
+
+  describe("tiered tolerance — no merchant match", () => {
+    it("rejects non-matching merchant regardless of amount", () => {
+      expect(scoreCandidates([tx("t1", 25.00, date, "lyft")], 25.00, date, "Starbucks")).toBeNull();
+    });
+
+    it("uses tight tolerance when no receiptMerchant provided", () => {
+      // $5 diff with no merchant → merchantMatched=false → exact $0.01 tolerance
+      expect(scoreCandidates([tx("t1", 30.00, date, "anymerchant")], 25.00, date, undefined)).toBeNull();
+    });
+
+    it("accepts exact match with no receiptMerchant", () => {
+      expect(scoreCandidates([tx("t1", 25.00, date, "anymerchant")], 25.00, date, undefined)).toBe("t1");
+    });
+  });
+
+  describe("sorting", () => {
+    it("picks closer amount when dates are equal", () => {
+      expect(scoreCandidates(
+        [tx("far", 28.00, date, "starbucks"), tx("near", 25.50, date, "starbucks")],
+        25.00, date, "Starbucks"
+      )).toBe("near");
+    });
+
+    it("picks closer date when amounts are equal", () => {
+      expect(scoreCandidates(
+        [tx("later", 25.00, "2025-03-20", "starbucks"), tx("sooner", 25.00, "2025-03-16", "starbucks")],
+        25.00, date, "Starbucks"
+      )).toBe("sooner");
+    });
+  });
+
+  it("returns null for empty candidates", () => {
+    expect(scoreCandidates([], 25.00, date, "Starbucks")).toBeNull();
+  });
+});
+
+// ─── Realistic match scenarios ────────────────────────────────────────────────
+
+describe("Realistic match scenarios", () => {
+  function tx(id: string, amount: number, date: string, merchant: string) {
+    return { id, amount, date, normalized_merchant: merchant, merchant_name: merchant };
+  }
+
+  it("SQ *MENSHO matches Mensho Tokyo SF receipt", () => {
+    expect(merchantsMatch("Mensho Tokyo SF", "SQ *MENSHO")).toBe(true);
+    expect(scoreCandidates(
+      [tx("wrong", 15.00, "2025-03-15", "some other"), tx("correct", 42.50, "2025-03-15", "mensho")],
+      42.50, "2025-03-14", "Mensho Tokyo SF"
+    )).toBe("correct");
+  });
+
+  it("Amazon receipt matches AMZN*MKTP US tx", () => {
+    expect(scoreCandidates(
+      [tx("wrong", 99.00, "2025-03-10", "target"), tx("correct", 45.99, "2025-03-12", "amzn mktp")],
+      45.99, "2025-03-11", "Amazon"
+    )).toBe("correct");
+  });
+
+  it("Lyft receipt matches LYFT *RIDE tx via alias", () => {
+    expect(merchantsMatch("Lyft", "LYFT *RIDE")).toBe(true);
+  });
+
+  it("prefers temporally closer tx when amounts are identical", () => {
+    expect(scoreCandidates(
+      [tx("old", 50.00, "2025-03-10", "starbucks"), tx("new", 50.00, "2025-03-16", "starbucks")],
+      50.00, "2025-03-15", "Starbucks"
+    )).toBe("new");
+  });
+
+  it("Airbnb receipt does NOT match Clipper tx (known conflict)", () => {
+    expect(merchantsMatch("Airbnb", "Clipper")).toBe(false);
+    expect(scoreCandidates(
+      [tx("clipper", 50.00, "2025-03-15", "clipper card")],
+      50.00, "2025-03-15", "Airbnb"
+    )).toBeNull();
+  });
+
+  it("CVS receipt matches CVS PHARMACY tx", () => {
+    expect(scoreCandidates(
+      [tx("t1", 12.50, "2025-03-15", "cvs pharmacy")],
+      12.50, "2025-03-15", "CVS"
+    )).toBe("t1");
+  });
+
+  it("Spotify receipt does not match Hulu tx (different groups)", () => {
+    expect(scoreCandidates(
+      [tx("hulu", 14.99, "2025-03-15", "hulu"), tx("spotify", 9.99, "2025-03-15", "spotify usa")],
+      9.99, "2025-03-15", "Spotify"
+    )).toBe("spotify");
+  });
+
+  it("Seamless receipt matches Grubhub tx via alias", () => {
+    expect(merchantsMatch("Seamless", "GRUBHUB")).toBe(true);
+  });
+
+  it("TST* restaurant receipt matches via POS stripping", () => {
+    expect(scoreCandidates(
+      [tx("t1", 67.40, "2025-03-15", "tartine manufactory")],
+      67.40, "2025-03-14", "TST*TARTINE MANUFACTORY"
+    )).toBe("t1");
+  });
+});

--- a/lib/__tests__/receipt-pipeline.test.ts
+++ b/lib/__tests__/receipt-pipeline.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Integration tests for the full email receipt pipeline:
+ *   Gmail API (mocked) → parseReceiptEmail (OpenAI mocked) → Supabase insert → match to transactions
+ *
+ * Covers:
+ *  - Pre-filters: excluded senders, Amazon shipped/delivered emails
+ *  - Merchant types: Starbucks (SQ * POS), Amazon (AMZN* tx), DoorDash, Spotify, Square restaurant
+ *  - Duplicate skipping: already-processed message IDs not re-parsed
+ *  - Match quality: correct transaction linked, NOT same-amount decoy
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── vi.hoisted runs BEFORE vi.mock factories and module evaluation ─────────────
+// Use it to: (1) set env so OpenAI client initializes, (2) build a mutable
+// create-mock that the OpenAI constructor can close over.
+const openaiMocks = vi.hoisted(() => {
+  process.env.OPENAI_API_KEY = "test-key-for-vitest";
+
+  // Mutable reference — tests swap this via setCreate()
+  let _create: (...args: unknown[]) => unknown = async () => ({
+    choices: [{ message: { content: '{"not_receipt":true}' } }],
+  });
+
+  // Regular function (not arrow) so it works with `new OpenAI()`
+  function OpenAIMock(this: unknown) {
+    return {
+      chat: { completions: { create: (...args: unknown[]) => _create(...args) } },
+    };
+  }
+
+  return {
+    OpenAIMock,
+    setCreate: (fn: typeof _create) => { _create = fn; },
+    resetCreate: () => {
+      _create = async () => ({
+        choices: [{ message: { content: '{"not_receipt":true}' } }],
+      });
+    },
+  };
+});
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("openai", () => ({ default: openaiMocks.OpenAIMock }));
+vi.mock("../google-auth", () => ({ getGmailClient: vi.fn() }));
+vi.mock("../supabase",    () => ({ getSupabase: vi.fn() }));
+vi.mock("../retry", () => ({
+  withRetry: vi.fn((fn: () => unknown) => fn()),
+  mapWithConcurrency: vi.fn(async (items: unknown[], fn: (item: unknown) => Promise<void>) => {
+    for (const item of items) await fn(item);
+  }),
+}));
+
+import { getGmailClient } from "../google-auth";
+import { getSupabase }    from "../supabase";
+import { withRetry, mapWithConcurrency } from "../retry";
+
+// ── Fake email bodies ──────────────────────────────────────────────────────────
+
+// Unique anchor strings used in setupParse() to route to the right parsed result
+const ANCHORS = {
+  starbucks: "STARBUCKS-RECEIPT-ANCHOR",
+  amazon:    "AMAZON-RECEIPT-ANCHOR",
+  doordash:  "DOORDASH-RECEIPT-ANCHOR",
+  spotify:   "SPOTIFY-RECEIPT-ANCHOR",
+  mensho:    "MENSHO-RECEIPT-ANCHOR",
+};
+
+const EMAIL = {
+  starbucks: `<h1>Starbucks Receipt ${ANCHORS.starbucks}</h1>
+    <p>Date: April 10, 2026</p>
+    <p>Grande Latte $6.25 | Blueberry Muffin $3.50 | Tax $0.85</p>
+    <p><strong>Total $10.60</strong></p>`,
+
+  amazon: `<h1>Amazon Order Confirmation ${ANCHORS.amazon}</h1>
+    <p>Order #112-5551234-9876543 placed April 11, 2026</p>
+    <p>Apple USB-C Cable $14.99 | Phone Stand $12.99 | Tax $2.52</p>
+    <p><strong>Order Total $30.50</strong></p>`,
+
+  doordash: `<h1>DoorDash Receipt ${ANCHORS.doordash}</h1>
+    <p>April 12, 2026 — Burma Bites</p>
+    <p>Chicken Noodle Soup $13.00 | Spring Rolls $9.00</p>
+    <p>Delivery $2.99 | Service fee $3.30 | Tip $5.00</p>
+    <p><strong>Total $33.29</strong></p>`,
+
+  spotify: `<p>Spotify Premium subscription renewed April 13, 2026 ${ANCHORS.spotify}</p>
+    <p><strong>Amount charged $11.99</strong></p>`,
+
+  mensho: `<h2>Receipt from Mensho Tokyo SF ${ANCHORS.mensho}</h2>
+    <p>April 9, 2026 — Ramen Tonkotsu $22.00 | Soft Drink $4.00 | Tax $2.34</p>
+    <p><strong>Total $28.34</strong></p>`,
+
+  investment: `<p>Your buy order for 10 shares of AAPL executed. Total $1,720.00</p>`,
+
+  amazonShipped: `<p>Your Amazon order has shipped! Tracking: 1Z999AA1</p>`,
+};
+
+// ── OpenAI parsed results (what the LLM would return) ────────────────────────
+
+const PARSED = {
+  starbucks: { merchant: "Starbucks", order_date: "2026-04-10", total_amount: 10.60, subtotal: 9.75, tax: 0.85, order_number: null, line_items: [{ name: "Grande Latte", quantity: 1, unit_price: 6.25, total: 6.25, category: "FOOD_AND_DRINK" }, { name: "Blueberry Muffin", quantity: 1, unit_price: 3.50, total: 3.50, category: "FOOD_AND_DRINK" }, { name: "Tax", quantity: 1, unit_price: 0.85, total: 0.85, category: "FOOD_AND_DRINK" }] },
+  amazon:    { merchant: "Amazon", order_date: "2026-04-11", total_amount: 30.50, subtotal: 27.98, tax: 2.52, order_number: "112-5551234-9876543", line_items: [{ name: "USB-C Cable", quantity: 1, unit_price: 14.99, total: 14.99, category: "ELECTRONICS" }, { name: "Phone Stand", quantity: 1, unit_price: 12.99, total: 12.99, category: "ELECTRONICS" }, { name: "Tax", quantity: 1, unit_price: 2.52, total: 2.52, category: "ELECTRONICS" }] },
+  doordash:  { merchant: "DoorDash", order_date: "2026-04-12", total_amount: 33.29, subtotal: 22.00, tax: null, order_number: null, line_items: [{ name: "Chicken Noodle Soup", quantity: 1, unit_price: 13.00, total: 13.00, category: "FOOD_AND_DRINK" }, { name: "Spring Rolls", quantity: 1, unit_price: 9.00, total: 9.00, category: "FOOD_AND_DRINK" }, { name: "Fees & Tip", quantity: 1, unit_price: 11.29, total: 11.29, category: "FOOD_AND_DRINK" }] },
+  spotify:   { merchant: "Spotify", order_date: "2026-04-13", total_amount: 11.99, subtotal: null, tax: null, order_number: null, line_items: [{ name: "Spotify Premium", quantity: 1, unit_price: 11.99, total: 11.99, category: "ENTERTAINMENT" }] },
+  mensho:    { merchant: "Mensho Tokyo SF", order_date: "2026-04-09", total_amount: 28.34, subtotal: 26.00, tax: 2.34, order_number: null, line_items: [{ name: "Ramen Tonkotsu", quantity: 1, unit_price: 22.00, total: 22.00, category: "FOOD_AND_DRINK" }, { name: "Soft Drink", quantity: 1, unit_price: 4.00, total: 4.00, category: "FOOD_AND_DRINK" }, { name: "Tax", quantity: 1, unit_price: 2.34, total: 2.34, category: "FOOD_AND_DRINK" }] },
+};
+
+// ── Fake Plaid transactions ────────────────────────────────────────────────────
+
+const FAKE_TXS = [
+  { id: "tx-sbux",    amount: 10.60, date: "2026-04-10", normalized_merchant: "starbucks",  merchant_name: "STARBUCKS #12345" },
+  { id: "tx-amzn",    amount: 30.50, date: "2026-04-12", normalized_merchant: "amzn mktp",  merchant_name: "AMZN*MKTP US" },
+  { id: "tx-dd",      amount: 33.29, date: "2026-04-13", normalized_merchant: "doordash",   merchant_name: "DOORDASH*BURMA" },
+  { id: "tx-spotify", amount: 11.99, date: "2026-04-13", normalized_merchant: "spotify",    merchant_name: "SPOTIFY USA" },
+  { id: "tx-mensho",  amount: 28.34, date: "2026-04-10", normalized_merchant: "mensho",     merchant_name: "SQ *MENSHO" },
+  // Decoy: same amount as Spotify, same day, different merchant
+  { id: "tx-decoy",   amount: 11.99, date: "2026-04-13", normalized_merchant: "hulu",       merchant_name: "HULU" },
+];
+
+// ── Gmail mock factory ─────────────────────────────────────────────────────────
+
+function makeMsg(id: string, from: string, subject: string, body: string) {
+  return {
+    data: {
+      id,
+      payload: {
+        headers: [{ name: "From", value: from }, { name: "Subject", value: subject }],
+        mimeType: "text/html",
+        body: { data: Buffer.from(body).toString("base64url") },
+      },
+    },
+  };
+}
+
+const MSGS: Record<string, ReturnType<typeof makeMsg>> = {
+  "msg-sbux":    makeMsg("msg-sbux",    "no-reply@starbucks.com",   "Your Starbucks receipt",              EMAIL.starbucks),
+  "msg-amazon":  makeMsg("msg-amazon",  "order-update@amazon.com",  "Ordered: Your Amazon order #112-555", EMAIL.amazon),
+  "msg-dd":      makeMsg("msg-dd",      "receipts@doordash.com",    "Your DoorDash receipt",               EMAIL.doordash),
+  "msg-spotify": makeMsg("msg-spotify", "no-reply@spotify.com",     "Your Spotify receipt",                EMAIL.spotify),
+  "msg-mensho":  makeMsg("msg-mensho",  "no-reply@squareup.com",    "Your receipt from Mensho Tokyo SF",   EMAIL.mensho),
+  "msg-invest":  makeMsg("msg-invest",  "noreply@questrade.com",    "Buy order executed: AAPL",            EMAIL.investment),
+  "msg-shipped": makeMsg("msg-shipped", "order-update@amazon.com",  "Your Amazon order has shipped!",      EMAIL.amazonShipped),
+};
+
+function gmail(ids: string[]) {
+  return {
+    users: {
+      messages: {
+        list: vi.fn().mockResolvedValue({ data: { messages: ids.map((id) => ({ id })) } }),
+        get: vi.fn().mockImplementation(async ({ id }: { id: string }) => {
+          if (!MSGS[id]) throw new Error(`Unknown msg id: ${id}`);
+          return MSGS[id];
+        }),
+      },
+    },
+  };
+}
+
+// ── Supabase stub ──────────────────────────────────────────────────────────────
+
+function makeDb(alreadyDone: string[] = []) {
+  const insertedReceipts: Record<string, unknown>[] = [];
+  const updatedMatches: Array<{ id: string; transaction_id: string }> = [];
+  let counter = 0;
+
+  function chain(val: unknown) {
+    const q: Record<string, unknown> = {};
+    const s = () => q;
+    q.select = s; q.eq = s; q.in = s; q.is = s;
+    q.not = s; q.gte = s; q.lte = s; q.maybeSingle = s;
+    q.then = (res: (v: unknown) => void) => { res(val); return Promise.resolve(val); };
+    return q;
+  }
+
+  const db = {
+    from: (table: string) => ({
+      select: (_cols?: string) => ({
+        // direct .in() — used by matchReceiptsToTransactions on email_receipts
+        in: (_c: string, ids: string[]) => ({
+          is: (_c2: string, _v2: unknown) => {
+            if (table === "email_receipts") {
+              const matched = insertedReceipts.filter((r) => ids.includes((r as Record<string,unknown>).id as string));
+              return chain({ data: matched, error: null });
+            }
+            return chain({ data: [], error: null });
+          },
+        }),
+        eq: (_c: string, _v: unknown) => ({
+          in: (_c2: string, ids: string[]) => {
+            if (table === "email_receipts" || table === "gmail_scan_log") {
+              const hits = ids.filter((id) => alreadyDone.includes(id));
+              return chain({ data: hits.map((id) => ({ gmail_message_id: id })), error: null });
+            }
+            if (table === "transactions") {
+              return chain({ data: FAKE_TXS.filter((tx) => ids.includes(tx.id)), error: null });
+            }
+            return chain({ data: [], error: null });
+          },
+          is:  (_c2: string, _v2: unknown) => chain({ data: [], error: null }),
+          not: (_c2: string, _op: string, _v2: unknown) => chain({ data: [], error: null }),
+          gte: (_c2: string, _v2: unknown) => ({
+            lte: (_c3: string, _v3: unknown) => chain({ data: FAKE_TXS, error: null }),
+          }),
+        }),
+        maybeSingle: () => chain({ data: null, error: null }),
+      }),
+      insert: (rows: unknown) => {
+        if (table === "email_receipts") {
+          const arr = Array.isArray(rows) ? rows : [rows];
+          const inserted = arr.map((r) => ({ ...r as object, id: `receipt-${++counter}` }));
+          inserted.forEach((r) => insertedReceipts.push(r));
+          return { select: () => chain({ data: inserted, error: null }) };
+        }
+        return chain({ data: null, error: null });
+      },
+      update: (patch: Record<string, unknown>) => ({
+        eq: (_c: string, id: unknown) => {
+          if (table === "email_receipts" && patch.transaction_id) {
+            updatedMatches.push({ id: id as string, transaction_id: patch.transaction_id as string });
+          }
+          return chain({ data: null, error: null });
+        },
+        in: () => chain({ data: null, error: null }),
+      }),
+      upsert: (rows: unknown, _opts?: unknown) => {
+        if (table === "email_receipts") {
+          const arr = Array.isArray(rows) ? rows : [rows];
+          const inserted = arr.map((r) => ({ ...r as object, id: `receipt-${++counter}` }));
+          inserted.forEach((r) => insertedReceipts.push(r));
+          return { select: (_cols?: string) => chain({ data: inserted, error: null }) };
+        }
+        return { select: () => chain({ data: null, error: null }) };
+      },
+    }),
+  };
+
+  return { db, insertedReceipts, updatedMatches };
+}
+
+// ── OpenAI response builder ────────────────────────────────────────────────────
+
+/** Sets up OpenAI mock to return the first matching parsed result based on body substring. */
+function setupParse(map: Array<[key: string, result: Record<string, unknown> | null]>) {
+  openaiMocks.setCreate(async (req: unknown) => {
+    const content = (req as { messages: Array<{ content: string }> }).messages[0]?.content ?? "";
+    let result: Record<string, unknown> | null = null;
+    for (const [key, val] of map) {
+      if (content.includes(key)) { result = val; break; }
+    }
+    return { choices: [{ message: { content: result == null ? '{"not_receipt":true}' : JSON.stringify(result) } }] };
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("Email receipt pipeline — full integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openaiMocks.resetCreate();
+    // Re-establish retry mock implementations wiped by vi.clearAllMocks()
+    (withRetry as ReturnType<typeof vi.fn>).mockImplementation((fn: () => unknown) => fn());
+    (mapWithConcurrency as ReturnType<typeof vi.fn>).mockImplementation(
+      async <T>(items: T[], fn: (item: T, index: number) => Promise<unknown>) => {
+        const results = [];
+        for (let i = 0; i < items.length; i++) results.push(await fn(items[i], i));
+        return results;
+      }
+    );
+  });
+
+  async function scan(...args: Parameters<Awaited<ReturnType<typeof getScanFn>>>) {
+    const fn = await getScanFn();
+    return fn(...args);
+  }
+
+  async function getScanFn() {
+    // Dynamic import so module re-evaluates with hoisted env + mocked OpenAI
+    const mod = await import("../receipt-parser");
+    return mod.scanGmailForReceipts;
+  }
+
+  // ── Pre-filters ──────────────────────────────────────────────────────────────
+
+  describe("Pre-filters", () => {
+    it("skips investment emails (questrade.com is excluded sender)", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-invest"]));
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.notReceipt).toBe(1);
+      expect(stats.parsed).toBe(0);
+      expect(insertedReceipts).toHaveLength(0);
+    });
+
+    it("skips Amazon shipped emails (only 'Ordered:' subject parsed)", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-shipped"]));
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.notReceipt).toBe(1);
+      expect(insertedReceipts).toHaveLength(0);
+    });
+
+    it("skips already-processed IDs when forceRescan=false", async () => {
+      const { db } = makeDb(["msg-sbux", "msg-spotify"]);
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+        gmail(["msg-sbux", "msg-spotify", "msg-amazon"])
+      );
+      setupParse([[ANCHORS.amazon, PARSED.amazon]]);
+
+      const stats = await scan("user_test", 30, false, false);
+
+      expect(stats.alreadyProcessed).toBe(2);
+      expect(stats.parsed).toBe(1); // only Amazon
+    });
+  });
+
+  // ── Parsing ──────────────────────────────────────────────────────────────────
+
+  describe("Parsing", () => {
+    it("parses Starbucks receipt — correct merchant, amount, date", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-sbux"]));
+      setupParse([[ANCHORS.starbucks, PARSED.starbucks]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.parsed).toBe(1);
+      expect(stats.insertErrors).toBe(0);
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "Starbucks", amount: 10.60, date: "2026-04-10" });
+    });
+
+    it("parses Amazon receipt — includes order_number", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-amazon"]));
+      setupParse([[ANCHORS.amazon, PARSED.amazon]]);
+
+      await scan("user_test", 30, false, true);
+
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "Amazon", amount: 30.50, order_number: "112-5551234-9876543" });
+    });
+
+    it("parses DoorDash delivery receipt", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-dd"]));
+      setupParse([[ANCHORS.doordash, PARSED.doordash]]);
+
+      await scan("user_test", 30, false, true);
+
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "DoorDash", amount: 33.29 });
+    });
+
+    it("parses Spotify subscription receipt", async () => {
+      const { db, insertedReceipts } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-spotify"]));
+      setupParse([[ANCHORS.spotify, PARSED.spotify]]);
+
+      await scan("user_test", 30, false, true);
+
+      expect(insertedReceipts[0]).toMatchObject({ merchant: "Spotify", amount: 11.99 });
+    });
+  });
+
+  // ── Matching ──────────────────────────────────────────────────────────────────
+
+  describe("Matching", () => {
+    it("matches Starbucks receipt to STARBUCKS transaction", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-sbux"]));
+      setupParse([[ANCHORS.starbucks, PARSED.starbucks]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-sbux")).toBe(true);
+    });
+
+    it("matches Amazon receipt to AMZN*MKTP US transaction (POS prefix stripped)", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-amazon"]));
+      setupParse([[ANCHORS.amazon, PARSED.amazon]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-amzn")).toBe(true);
+    });
+
+    it("matches Spotify receipt to SPOTIFY USA — NOT the $11.99 Hulu decoy on same day", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-spotify"]));
+      setupParse([[ANCHORS.spotify, PARSED.spotify]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-spotify")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-decoy")).toBe(false);
+    });
+
+    it("matches Mensho Tokyo SF receipt to SQ *MENSHO transaction (POS prefix stripping)", async () => {
+      const { db, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(gmail(["msg-mensho"]));
+      setupParse([[ANCHORS.mensho, PARSED.mensho]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.matched).toBe(1);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-mensho")).toBe(true);
+    });
+
+    it("batch: all 5 receipts parsed and each matched to the correct transaction", async () => {
+      const { db, insertedReceipts, updatedMatches } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+        gmail(["msg-sbux", "msg-amazon", "msg-dd", "msg-spotify", "msg-mensho"])
+      );
+      setupParse([
+        [ANCHORS.starbucks, PARSED.starbucks],
+        [ANCHORS.amazon,    PARSED.amazon],
+        [ANCHORS.doordash,  PARSED.doordash],
+        [ANCHORS.spotify,   PARSED.spotify],
+        [ANCHORS.mensho,    PARSED.mensho],
+      ]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.parsed).toBe(5);
+      expect(stats.insertErrors).toBe(0);
+      expect(insertedReceipts).toHaveLength(5);
+      expect(stats.matched).toBe(5);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-sbux")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-amzn")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-dd")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-spotify")).toBe(true);
+      expect(updatedMatches.some((m) => m.transaction_id === "tx-mensho")).toBe(true);
+    });
+  });
+
+  // ── Scan stats ────────────────────────────────────────────────────────────────
+
+  describe("Scan stats", () => {
+    it("counts notReceipt + parsed correctly in a mixed batch", async () => {
+      const { db } = makeDb();
+      (getSupabase as ReturnType<typeof vi.fn>).mockReturnValue(db);
+      (getGmailClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+        gmail(["msg-sbux", "msg-invest", "msg-shipped"])
+      );
+      setupParse([[ANCHORS.starbucks, PARSED.starbucks]]);
+
+      const stats = await scan("user_test", 30, false, true);
+
+      expect(stats.emailsFetched).toBe(3);
+      expect(stats.parsed).toBe(1);     // Starbucks only
+      expect(stats.notReceipt).toBe(2); // investment + shipped
+    });
+  });
+});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -113,14 +113,27 @@ export const GMAIL = {
 } as const;
 
 export const RECEIPT_MATCH = {
-  AMOUNT_TOLERANCE_DOLLARS: 5,
-  AMOUNT_TOLERANCE_PERCENT: 0.20,
-  DATE_WINDOW_DAYS: 7,
+  // Amount tolerance when merchant name matches (tiered: min of dollars vs percent)
+  AMOUNT_TOLERANCE_DOLLARS: 5.0,
+  AMOUNT_TOLERANCE_PERCENT: 0.10,
+  // Exact tolerance for Strategy 3 (no merchant signal)
+  AMOUNT_TOLERANCE_EXACT: 0.01,
+  // Asymmetric date windows — receipt date is order date, bank posts later
+  WINDOW_BEFORE_DAYS: 3,
+  WINDOW_AFTER_DAYS: 10,
+  TIGHT_WINDOW_BEFORE_DAYS: 1,
+  TIGHT_WINDOW_AFTER_DAYS: 4,
   MIN_KEYWORD_LENGTH: 3,
+  MAX_KEYWORDS: 7,
   STOP_WORDS: new Set([
     "the", "and", "for", "inc", "llc", "ltd", "com", "www", "online",
     "payment", "pay", "purchase", "store", "shop", "receipt", "order",
     "confirmation", "your", "thank", "you",
+    "service", "services", "app", "group", "co", "corp",
+    "new", "usa", "us", "get", "my",
+    "restaurant", "bar", "grill", "cafe", "kitchen", "coffee",
+    "delivery", "shipping", "express",
+    "airlines", "airline", "air", "travel",
   ]),
 } as const;
 

--- a/lib/receipt-matcher.ts
+++ b/lib/receipt-matcher.ts
@@ -1,8 +1,13 @@
 import { getSupabase } from "./supabase";
 import { RECEIPT_MATCH } from "./config";
 
+// Regex that strips POS processor prefixes (Square, Toast, PayPal, Shopify, etc.)
+// before normalization so "SQ *MENSHO" and "Mensho Tokyo SF" compare correctly.
+const POS_PREFIX_RE = /^(?:sq\s?\*|tst\s?\*?|pp\s?\*|paypal\s+|sp\s?\*|google\s?\*|amzn\*|checkcard\s+|pos\s+)/i;
+
 export function normalizeMerchant(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/\s+/g, " ").trim();
+  const stripped = s.replace(POS_PREFIX_RE, "");
+  return stripped.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/\s+/g, " ").trim();
 }
 
 function sanitizeForIlike(s: string): string {
@@ -51,6 +56,13 @@ const MERCHANT_ALIASES: Record<string, string[]> = {
   lowes: ["lowes", "lowe"],
   fantuan: ["fantuan", "fantuanorder"],
   skipthedishes: ["skip the dishes", "skipthedishes"],
+  sephora: ["sephora"],
+  nike: ["nike"],
+  chewy: ["chewy"],
+  etsy: ["etsy"],
+  disney: ["disney", "disney plus", "disneyplus"],
+  github: ["github"],
+  openai: ["openai", "openai chatgpt"],
 };
 
 const POS_PREFIXES = [
@@ -70,19 +82,47 @@ function stripPosPrefix(merchant: string): string {
   return merchant;
 }
 
-function resolveAliases(merchant: string): string[] {
+/**
+ * Returns the canonical alias group key(s) that a merchant belongs to.
+ * Used ONLY for group-membership checks (same group = same merchant).
+ * Intentionally excludes sub-tokens to prevent cross-group collisions
+ * (e.g. "airlines" appearing in both Delta and United).
+ */
+function resolveAliasGroups(merchant: string): string[] {
   const norm = normalizeMerchant(merchant);
-  const extra: string[] = [];
+  const groups: string[] = [];
   for (const [canonical, aliases] of Object.entries(MERCHANT_ALIASES)) {
     if (aliases.some((a) => norm.includes(a)) || norm.includes(canonical)) {
-      extra.push(canonical);
+      groups.push(canonical);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Returns all alias tokens (canonical key + individual words from alias strings)
+ * for a merchant. Used for keyword extraction.
+ * Stop words and short tokens are filtered to avoid generic tokens (e.g. "air")
+ * from alias phrases causing cross-group false positives.
+ */
+function resolveAliasKeywords(merchant: string): string[] {
+  const norm = normalizeMerchant(merchant);
+  const tokens: string[] = [];
+  for (const [canonical, aliases] of Object.entries(MERCHANT_ALIASES)) {
+    if (aliases.some((a) => norm.includes(a)) || norm.includes(canonical)) {
+      if (!RECEIPT_MATCH.STOP_WORDS.has(canonical) && canonical.length >= RECEIPT_MATCH.MIN_KEYWORD_LENGTH) {
+        tokens.push(canonical);
+      }
       for (const a of aliases) {
-        const kw = a.split(" ")[0];
-        if (kw.length >= 3 && !extra.includes(kw)) extra.push(kw);
+        for (const word of a.split(" ")) {
+          if (word.length >= RECEIPT_MATCH.MIN_KEYWORD_LENGTH && !RECEIPT_MATCH.STOP_WORDS.has(word) && !tokens.includes(word)) {
+            tokens.push(word);
+          }
+        }
       }
     }
   }
-  return extra;
+  return tokens;
 }
 
 export function extractKeywords(merchant: string): string[] {
@@ -95,7 +135,7 @@ export function extractKeywords(merchant: string): string[] {
     .map(sanitizeForIlike)
     .filter((w) => w.length > 0);
 
-  const aliasKeywords = resolveAliases(merchant)
+  const aliasKeywords = resolveAliasKeywords(merchant)
     .map(sanitizeForIlike)
     .filter((w) => w.length > 0);
 
@@ -107,7 +147,7 @@ export function extractKeywords(merchant: string): string[] {
       result.push(w);
     }
   }
-  return result.slice(0, 5);
+  return result.slice(0, RECEIPT_MATCH.MAX_KEYWORDS);
 }
 
 export function merchantsMatch(receiptMerchant: string, txMerchant: string): boolean {
@@ -123,21 +163,41 @@ export function merchantsMatch(receiptMerchant: string, txMerchant: string): boo
   const bKeywords = b.split(" ").filter((w) => w.length >= 3);
   if (bKeywords.some((kw) => a.includes(kw))) return true;
 
-  const aAliases = resolveAliases(receiptMerchant);
-  const bAliases = resolveAliases(stripPosPrefix(txMerchant));
-  if (aAliases.length > 0 && bAliases.length > 0) {
-    if (aAliases.some((aa) => bAliases.includes(aa))) return true;
+  // Group check: same canonical alias group = same merchant
+  const aGroups = resolveAliasGroups(receiptMerchant);
+  const bGroups = resolveAliasGroups(txMerchant);
+  if (aGroups.length > 0 && bGroups.length > 0) {
+    if (aGroups.some((g) => bGroups.includes(g))) return true;
   }
-  if (aAliases.some((aa) => b.includes(aa))) return true;
-  if (bAliases.some((ba) => a.includes(ba))) return true;
+
+  // Keyword check: alias tokens from one side appear as whole words in the other.
+  // Use word-token matching (not substring) to prevent e.g. "delta" alias token
+  // "air" matching inside "united airlines".
+  const aWords = new Set(a.split(" "));
+  const bWords = new Set(b.split(" "));
+  const aKeywordAliases = resolveAliasKeywords(receiptMerchant);
+  const bKeywordAliases = resolveAliasKeywords(txMerchant);
+  if (aKeywordAliases.some((kw) => bWords.has(kw))) return true;
+  if (bKeywordAliases.some((kw) => aWords.has(kw))) return true;
 
   return false;
 }
 
-function amountWithinTolerance(receiptAmount: number, txAmount: number): boolean {
-  // Exact match only — $0.01 rounding buffer for floating-point representation.
-  // Loose dollar/percent tolerances caused too many false matches on small amounts.
-  return Math.abs(txAmount - receiptAmount) <= 0.01;
+/**
+ * Tiered amount tolerance:
+ * - merchantMatched=true: min($DOLLARS, PERCENT*receiptAmount) — generous for known merchants
+ * - merchantMatched=false: exact $0.01 — tight for amount-only Strategy 3 matches
+ */
+function amountWithinTolerance(receiptAmount: number, txAmount: number, merchantMatched = false): boolean {
+  const diff = Math.abs(txAmount - receiptAmount);
+  if (merchantMatched) {
+    const tolerance = Math.min(
+      RECEIPT_MATCH.AMOUNT_TOLERANCE_DOLLARS,
+      receiptAmount * RECEIPT_MATCH.AMOUNT_TOLERANCE_PERCENT
+    );
+    return diff <= Math.max(tolerance, RECEIPT_MATCH.AMOUNT_TOLERANCE_EXACT);
+  }
+  return diff <= RECEIPT_MATCH.AMOUNT_TOLERANCE_EXACT;
 }
 
 /**
@@ -147,8 +207,8 @@ function amountWithinTolerance(receiptAmount: number, txAmount: number): boolean
  */
 function knownMerchantsConflict(m1: string, m2: string): boolean {
   if (!m1 || !m2) return false;
-  const a1 = resolveAliases(m1);
-  const a2 = resolveAliases(m2);
+  const a1 = resolveAliasGroups(m1);
+  const a2 = resolveAliasGroups(m2);
   // Both are recognised merchants and share no alias group → definitively different
   return a1.length > 0 && a2.length > 0 && !a1.some((a) => a2.includes(a));
 }
@@ -174,12 +234,13 @@ export function scoreCandidates(
       };
     })
     .filter((s) => {
-      if (!amountWithinTolerance(receiptAmount, receiptAmount + s.amountDiff)) return false;
+      const txMerch = s.normalized_merchant || s.merchant_name || "";
+      const merchantMatched = Boolean(receiptMerchant && txMerch && merchantsMatch(receiptMerchant, txMerch));
 
-      if (receiptMerchant) {
-        const txMerch = s.normalized_merchant || s.merchant_name || "";
-        if (txMerch && !merchantsMatch(receiptMerchant, txMerch)) return false;
-      }
+      if (!amountWithinTolerance(receiptAmount, receiptAmount + s.amountDiff, merchantMatched)) return false;
+
+      // If a merchant is provided but doesn't match, reject (unless merchantMatched is true)
+      if (receiptMerchant && txMerch && !merchantMatched) return false;
 
       return true;
     })
@@ -226,16 +287,17 @@ export async function matchReceiptsToTransactions(
     (alreadyLinked ?? []).map((r) => r.transaction_id as string).filter(Boolean)
   );
 
-  const windowDays = RECEIPT_MATCH.DATE_WINDOW_DAYS;
+  const windowBeforeDays = RECEIPT_MATCH.WINDOW_BEFORE_DAYS;
+  const windowAfterDays = RECEIPT_MATCH.WINDOW_AFTER_DAYS;
 
-  // Collect the overall date range covering ALL receipts (+ window on each side)
+  // Collect the overall date range covering ALL receipts (+ asymmetric window)
   let globalMinDate: Date | null = null;
   let globalMaxDate: Date | null = null;
   for (const receipt of receipts) {
     if (!receipt.date) continue;
     const d = new Date(receipt.date);
-    const lo = new Date(d); lo.setDate(lo.getDate() - windowDays);
-    const hi = new Date(d); hi.setDate(hi.getDate() + windowDays);
+    const lo = new Date(d); lo.setDate(lo.getDate() - windowBeforeDays);
+    const hi = new Date(d); hi.setDate(hi.getDate() + windowAfterDays);
     if (!globalMinDate || lo < globalMinDate) globalMinDate = lo;
     if (!globalMaxDate || hi > globalMaxDate) globalMaxDate = hi;
   }
@@ -252,8 +314,6 @@ export async function matchReceiptsToTransactions(
       .lte("date", globalMaxDate.toISOString().split("T")[0]);
     allCandidates = (txRows ?? []) as TxCandidate[];
   }
-
-  const tightWindowDays = 5;
 
   let matched = 0;
   const pendingUpdates: Array<{ id: string; transaction_id: string }> = [];
@@ -277,13 +337,13 @@ export async function matchReceiptsToTransactions(
     let tightEnd: string | undefined;
     if (receiptDate) {
       const dateObj = new Date(receiptDate);
-      const start = new Date(dateObj); start.setDate(start.getDate() - windowDays);
-      const end = new Date(dateObj); end.setDate(end.getDate() + windowDays);
+      const start = new Date(dateObj); start.setDate(start.getDate() - windowBeforeDays);
+      const end = new Date(dateObj); end.setDate(end.getDate() + windowAfterDays);
       dateStart = start.toISOString().split("T")[0];
       dateEnd = end.toISOString().split("T")[0];
 
-      const ts = new Date(dateObj); ts.setDate(ts.getDate() - tightWindowDays);
-      const te = new Date(dateObj); te.setDate(te.getDate() + tightWindowDays);
+      const ts = new Date(dateObj); ts.setDate(ts.getDate() - RECEIPT_MATCH.TIGHT_WINDOW_BEFORE_DAYS);
+      const te = new Date(dateObj); te.setDate(te.getDate() + RECEIPT_MATCH.TIGHT_WINDOW_AFTER_DAYS);
       tightStart = ts.toISOString().split("T")[0];
       tightEnd = te.toISOString().split("T")[0];
     }
@@ -342,7 +402,7 @@ export async function matchReceiptsToTransactions(
               txAmount,
             };
           })
-          .filter((s) => amountWithinTolerance(tryAmount, tryAmount + s.amountDiff) && isFinite(s.dateDiff))
+          .filter((s) => amountWithinTolerance(tryAmount, tryAmount + s.amountDiff, true) && isFinite(s.dateDiff))
           .sort((a, b) => a.amountDiff - b.amountDiff || a.dateDiff - b.dateDiff);
 
         if (scored.length > 0) {
@@ -393,7 +453,7 @@ export async function matchReceiptsToTransactions(
         })
         .sort((a, b) => a.amountDiff - b.amountDiff);
       const best = closest[0];
-      let reason = `no candidates in ±${windowDays}d window`;
+      let reason = `no candidates in -${windowBeforeDays}/+${windowAfterDays}d window`;
       if (best) {
         const parts: string[] = [];
         if (best.amountDiff > 0.01) parts.push(`closest amount diff=$${best.amountDiff.toFixed(2)}`);


### PR DESCRIPTION
## Summary

- **POS prefix stripping** — `normalizeMerchant` now strips `SQ*`, `TST*`, `AMZN*`, `PP*`, `SP*`, `Google*`, `PayPal`, `CHECKCARD`, `POS` so `SQ *MENSHO` correctly matches `Mensho Tokyo SF`
- **Alias group separation** — split `resolveAliases` into `resolveAliasGroups` (group membership check) and `resolveAliasKeywords` (word-boundary search), fixing Delta/United cross-matching via shared "airlines" token
- **New aliases** — sephora, nike, chewy, etsy, disney, github, openai
- **Tiered amount tolerance** — merchant-matched uses `min($5, 10%)`, no-merchant uses exact `$0.01` to prevent false positives
- **Asymmetric date window** — `-3/+10` days (receipt = order date, bank posts later) instead of symmetric `±7`

## Tests

- `lib/__tests__/receipt-matcher.test.ts` — 68 unit tests (normalizeMerchant, merchantsMatch, extractKeywords, scoreCandidates)
- `lib/__tests__/receipt-pipeline.test.ts` — 13 integration tests with fake receipt emails, mocked Gmail/OpenAI/Supabase, verifying full parse→match pipeline including Spotify vs Hulu decoy avoidance and SQ*MENSHO POS prefix stripping

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` receipt files — 81/81 pass
- [ ] Verify on prod: trigger a Gmail scan and check match rate improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)