### PR TITLE
fix: bug council audit — 3 bugs fixed

### DIFF
--- a/app/api/cards/__tests__/middleware-public-routes.test.ts
+++ b/app/api/cards/__tests__/middleware-public-routes.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Tests for BUG-CRITICAL-1: card routes must be in the isPublicRoute matcher.
+ *
+ * createRouteMatcher from @clerk/nextjs/server cannot be instantiated in a
+ * Vitest unit-test environment (requires full Next.js middleware runtime).
+ * Instead, we inspect the middleware source to confirm the required route
+ * strings are present in the isPublicRoute call.
+ *
+ * These tests FAIL against the old code (routes absent) and PASS after the fix.
+ */
+
+const middlewareSrc = readFileSync(
+  join(process.cwd(), "middleware.ts"),
+  "utf-8"
+);
+
+describe("middleware.ts isPublicRoute (BUG-CRITICAL-1)", () => {
+  it("includes /cards for unauthenticated UI access", () => {
+    expect(middlewareSrc).toContain('"/cards"');
+  });
+
+  it("includes /api/cards/create-link-token for unauthenticated Plaid link token creation", () => {
+    expect(middlewareSrc).toContain('"/api/cards/create-link-token"');
+  });
+
+  it("includes /api/cards/analyze-plaid for unauthenticated transaction analysis", () => {
+    expect(middlewareSrc).toContain('"/api/cards/analyze-plaid"');
+  });
+
+  it("includes /api/cards/list for unauthenticated card listing", () => {
+    expect(middlewareSrc).toContain('"/api/cards/list"');
+  });
+
+  it("includes /api/cards/recommend for session-based unauthenticated recommendations", () => {
+    expect(middlewareSrc).toContain('"/api/cards/recommend"');
+  });
+
+  it("does NOT include /api/cards/analyze-coconut as public (requires Coconut user auth)", () => {
+    // analyze-coconut must remain protected — should NOT appear in the isPublicRoute list
+    const publicRouteBlock = middlewareSrc.match(
+      /const isPublicRoute = createRouteMatcher\(\[([\s\S]*?)\]\)/
+    )?.[1] ?? "";
+    expect(publicRouteBlock).not.toContain('"/api/cards/analyze-coconut"');
+  });
+});

--- a/hooks/useSubscriptions.test.ts
+++ b/hooks/useSubscriptions.test.ts
@@ -200,6 +200,60 @@ describe("useSubscriptions – dismiss mountedRef guard", () => {
     await waitFor(() => expect(result.current.detecting).toBe(false));
   });
 
+  it("resets loading to false after detect() receives a non-200 response", async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET
+      .mockResolvedValueOnce({ ok: true, json: async () => [SUB] })
+      // POST detect returns non-200
+      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: "Detection failed. Please try again." }) });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useSubscriptions());
+
+    // Wait for initial load to complete
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Trigger detect and wait for it to finish
+    await act(async () => {
+      await result.current.detect();
+    });
+
+    // loading must be false after the failed detect() call
+    expect(result.current.loading).toBe(false);
+    // detecting must also be false
+    expect(result.current.detecting).toBe(false);
+    // error should be set
+    expect(result.current.error).toBe("Detection failed. Please try again.");
+  });
+
+  it("resets loading to false after detect() throws a network error", async () => {
+    const fetchMock = vi
+      .fn()
+      // initial GET
+      .mockResolvedValueOnce({ ok: true, json: async () => [SUB] })
+      // POST detect throws
+      .mockRejectedValueOnce(new Error("network error"));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useSubscriptions());
+
+    // Wait for initial load to complete
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Trigger detect and wait for it to finish
+    await act(async () => {
+      await result.current.detect();
+    });
+
+    // loading must be false after the network error
+    expect(result.current.loading).toBe(false);
+    // detecting must also be false
+    expect(result.current.detecting).toBe(false);
+  });
+
   it("calls fetchSubs when PATCH fails and component is still mounted (dismiss)", async () => {
     const fetchMock = vi
       .fn()

--- a/hooks/useSubscriptions.ts
+++ b/hooks/useSubscriptions.ts
@@ -80,7 +80,10 @@ export function useSubscriptions() {
       if (mountedRef.current && !cancelled) setError("Detection failed. Please try again.");
     } finally {
       cancelled = true;
-      if (mountedRef.current) setDetecting(false);
+      if (mountedRef.current) {
+        setDetecting(false);
+        setLoading(false);
+      }
     }
   }, [fetchSubs]);
 

--- a/lib/__tests__/subscription-detect.test.ts
+++ b/lib/__tests__/subscription-detect.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../supabase", () => ({ getSupabase: vi.fn() }));
+vi.mock("../subscription-config", () => ({ shouldExcludeAsSubscription: vi.fn(() => false) }));
+vi.mock("../known-subscriptions", () => ({ matchKnownSubscription: vi.fn(() => null) }));
+
+import { getSupabase } from "../supabase";
+import { saveDetectedSubscriptions, type DetectedSubscription } from "../subscription-detect";
+
+const mockGetSupabase = vi.mocked(getSupabase);
+
+const DETECTED: DetectedSubscription = {
+  merchantName: "Netflix",
+  normalizedMerchant: "netflix",
+  amount: 15.99,
+  frequency: "monthly",
+  lastChargeDate: "2026-04-01",
+  nextDueDate: "2026-05-01",
+  primaryCategory: "Entertainment",
+  transactionCount: 3,
+  transactionIds: [],
+  transactionDetails: [],
+  source: "known",
+  confidence: 0.95,
+};
+
+function makeQueryBuilder(overrides: Record<string, unknown> = {}) {
+  const builder: Record<string, unknown> = {
+    select: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+    eq: vi.fn(),
+    neq: vi.fn(),
+    in: vi.fn(),
+    then: undefined,
+    ...overrides,
+  };
+  // Make each method return the builder itself for chaining by default
+  (builder.select as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+  (builder.update as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+  (builder.upsert as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+  (builder.eq as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+  (builder.neq as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+  (builder.in as ReturnType<typeof vi.fn>).mockReturnValue(builder);
+  return builder;
+}
+
+describe("saveDetectedSubscriptions – Promise.all error propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when .update() returns { error } (existing subscription path)", async () => {
+    const dbError = new Error("DB update error");
+
+    // We need two different "from" calls:
+    // 1st: SELECT existing subscriptions → returns existing row so code takes toUpdate path
+    // 2nd: the actual UPDATE call → returns { error }
+
+    let callCount = 0;
+    const selectBuilder = makeQueryBuilder();
+    // The select chain terminates with a promise-like that resolves to { data: [existing] }
+    (selectBuilder.in as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: [{ id: "sub-existing-1", status: "active", amount: 15.99, normalized_merchant: "netflix" }],
+    });
+
+    const updateBuilder = makeQueryBuilder();
+    // The update chain terminates (after .neq()) with a promise-like that resolves to { error }
+    (updateBuilder.neq as ReturnType<typeof vi.fn>).mockResolvedValue({ error: dbError });
+
+    mockGetSupabase.mockReturnValue({
+      from: vi.fn(() => {
+        callCount++;
+        if (callCount === 1) return selectBuilder as unknown as ReturnType<ReturnType<typeof getSupabase>["from"]>;
+        return updateBuilder as unknown as ReturnType<ReturnType<typeof getSupabase>["from"]>;
+      }),
+    } as unknown as ReturnType<typeof getSupabase>);
+
+    await expect(saveDetectedSubscriptions("user-1", [DETECTED])).rejects.toThrow("DB update error");
+  });
+
+  it("throws when .upsert() returns { error } (new subscription path)", async () => {
+    const dbError = new Error("DB upsert error");
+
+    let callCount = 0;
+    const selectBuilder = makeQueryBuilder();
+    // SELECT returns empty → code takes toUpsert path
+    (selectBuilder.in as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [] });
+
+    const upsertBuilder = makeQueryBuilder();
+    // upsert resolves to { error }
+    (upsertBuilder.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({ error: dbError });
+
+    mockGetSupabase.mockReturnValue({
+      from: vi.fn(() => {
+        callCount++;
+        if (callCount === 1) return selectBuilder as unknown as ReturnType<ReturnType<typeof getSupabase>["from"]>;
+        return upsertBuilder as unknown as ReturnType<ReturnType<typeof getSupabase>["from"]>;
+      }),
+    } as unknown as ReturnType<typeof getSupabase>);
+
+    await expect(saveDetectedSubscriptions("user-1", [DETECTED])).rejects.toThrow("DB upsert error");
+  });
+});

--- a/lib/subscription-detect.ts
+++ b/lib/subscription-detect.ts
@@ -504,11 +504,13 @@ export async function saveDetectedSubscriptions(clerkUserId: string, detected: D
         .update(u.data)
         .eq("id", u.id)
         .neq("status", "dismissed")
+        .then(({ error }) => { if (error) throw error; })
     ),
     toUpsert.length > 0
       ? db
           .from("subscriptions")
           .upsert(toUpsert, { onConflict: "clerk_user_id,normalized_merchant", ignoreDuplicates: true })
+          .then(({ error }) => { if (error) throw error; })
       : Promise.resolve(),
   ]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -28,6 +28,12 @@ const isPublicRoute = createRouteMatcher([
   "/api/splitwise/shadow-crud-test",
   // Mirror debug endpoints — admin auth handled in route (ENABLE_DEBUG_ENDPOINTS=true required)
   "/api/debug/splitwise-mirror(.*)",
+  // Card recommendation tool — designed for unauthenticated (new) users
+  "/cards",
+  "/api/cards/create-link-token",
+  "/api/cards/analyze-plaid",
+  "/api/cards/list",
+  "/api/cards/recommend",
 ]);
 
 function isClerkRateLimitError(e: unknown): e is { status: number; retryAfter?: number } {


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 5
**Bugs verified (survived Devil's Advocate)**: 3
**Bugs fixed (with tests)**: 3
**Bugs deferred**: 0
**False positives rejected**: 1 (BUG-DAILY-1: double currency conversion disproved — single-conversion per layer is correct architecture)

## Fixed Bugs

### P0 — Critical
None

### P1 — Broken Functionality

**BUG-CRITICAL-1**: Card routes (`/cards`, `/api/cards/create-link-token`, `/api/cards/analyze-plaid`, `/api/cards/list`, `/api/cards/recommend`) were missing from the `isPublicRoute` matcher in `middleware.ts` — unauthenticated users (the intended audience for this tool) received 401 or login redirect, making the entire card recommendation feature broken for new users. — `middleware.ts` (test: `app/api/cards/__tests__/middleware-public-routes.test.ts`)

**BUG-CLIENT-2**: `saveDetectedSubscriptions()` in `lib/subscription-detect.ts` spread Supabase `.update()` and `.upsert()` calls into `Promise.all` without chaining `.then(({ error }) => { if (error) throw error; })`. Supabase returns errors as objects (not thrown), so database failures were silently swallowed — subscriptions appeared to save but didn't, and transaction linking in Phase 3 would proceed with missing subscription IDs. — `lib/subscription-detect.ts` (test: `lib/__tests__/subscription-detect.test.ts`)

### P2 — Incorrect Behavior

**BUG-CLIENT-1**: `detect()` in `hooks/useSubscriptions.ts` set `setLoading(true)` at start but the `finally` block only called `setDetecting(false)`, never `setLoading(false)`. After any detection error (non-200 response or network exception), the loading spinner stayed stuck indefinitely. — `hooks/useSubscriptions.ts` (test: `hooks/useSubscriptions.test.ts`)

## Tests Added
- `app/api/cards/__tests__/middleware-public-routes.test.ts` — 6 source-inspection tests verifying card route strings are present in the `isPublicRoute` matcher
- `lib/__tests__/subscription-detect.test.ts` — 2 tests verifying `saveDetectedSubscriptions` throws when Supabase update/upsert returns an error
- `hooks/useSubscriptions.test.ts` — 2 tests verifying `detect()` resets `loading` to `false` after error response and after network exception

## Deferred Bugs (Not Fixed)
None

## Disproved Bugs (Rejected by Devil's Advocate)
- **BUG-DAILY-1**: Reported as "double currency conversion for netWorth". Disproved — the architecture is correct single-conversion per layer: API converts account/wallet balances from native currency to USD as a baseline, and the frontend then converts USD to the user's display currency. This is intentional.

## Patterns Found
- **Card routes/middleware gap**: New API features for unauthenticated users must be added to `isPublicRoute` in middleware. This is the second time this pattern has appeared (handoff-token was fixed in PR #245). No new `.cursor/rules` update needed — pattern is already documented.

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (no new errors vs baseline, same 68 warnings)
- [x] `npm run test` — passes (54 test files, 540 tests; +2 files, +10 tests vs baseline)

---
Generated by Bug Council v2 (evidence-based)