### PR TITLE
feat: add value breakdown + sign-up bonus tooltip to /cards

### DIFF
--- a/app/cards/page.tsx
+++ b/app/cards/page.tsx
@@ -49,10 +49,24 @@ interface CardData {
   rewards_value_cpp: number;
   earn_rates: Record<string, number>;
   sign_up_bonus_value: number;
+  sign_up_bonus_spend: number;
+  sign_up_bonus_days: number;
   foreign_transaction_fee: boolean;
   key_perks: string[];
   pairs_well_with: string[];
   apply_url?: string | null;
+}
+
+interface ValueBreakdown {
+  dining: number;
+  travel: number;
+  groceries: number;
+  gas: number;
+  streaming: number;
+  transit: number;
+  other: number;
+  annual_fee_cost: number;
+  sign_up_bonus_contribution: number;
 }
 
 interface Recommendation {
@@ -60,6 +74,7 @@ interface Recommendation {
   score: number;
   estimated_annual_value: number;
   reason: string;
+  value_breakdown?: ValueBreakdown;
   card: CardData | null;
 }
 
@@ -539,8 +554,27 @@ function ResultCard({
   rank: number;
 }) {
   const [perksOpen, setPerksOpen] = useState(false);
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
   const card = rec.card;
   if (!card) return null;
+
+  const bd = rec.value_breakdown;
+  const CATEGORY_LABELS: Array<[keyof ValueBreakdown, string]> = [
+    ["dining", "Dining"],
+    ["groceries", "Groceries"],
+    ["travel", "Travel"],
+    ["gas", "Gas"],
+    ["streaming", "Streaming"],
+    ["transit", "Transit"],
+    ["other", "Everything else"],
+  ];
+  const spendCategories = bd
+    ? CATEGORY_LABELS.filter(([k]) => (bd[k] as number) > 0).map(([k, label]) => ({
+        label,
+        value: bd[k] as number,
+        rate: card.earn_rates[k === "other" ? "base" : k] ?? card.earn_rates["base"] ?? 1,
+      }))
+    : [];
 
   const pairNames = card.pairs_well_with
     .map((id) => allCards.get(id)?.name)
@@ -573,6 +607,46 @@ function ResultCard({
           </div>
         </div>
         <p className="text-sm text-gray-600 mt-2 leading-relaxed">{rec.reason}</p>
+
+        {/* Value breakdown */}
+        {bd && spendCategories.length > 0 && (
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={() => setBreakdownOpen((p) => !p)}
+              className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800 transition-colors"
+            >
+              How we get to ~{formatCurrency(rec.estimated_annual_value)}/yr
+              {breakdownOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            </button>
+            {breakdownOpen && (
+              <div className="mt-2 rounded-lg bg-gray-50 border border-gray-100 divide-y divide-gray-100 text-xs">
+                {spendCategories.map(({ label, value, rate }) => (
+                  <div key={label} className="flex justify-between items-center px-3 py-1.5">
+                    <span className="text-gray-600">{label} <span className="text-gray-400">({rate}x)</span></span>
+                    <span className="font-medium text-gray-800">+{formatCurrency(value)}/yr</span>
+                  </div>
+                ))}
+                {bd.annual_fee_cost < 0 && (
+                  <div className="flex justify-between items-center px-3 py-1.5">
+                    <span className="text-gray-600">Annual fee</span>
+                    <span className="font-medium text-red-500">{formatCurrency(bd.annual_fee_cost)}/yr</span>
+                  </div>
+                )}
+                {bd.sign_up_bonus_contribution > 0 && (
+                  <div className="flex justify-between items-center px-3 py-1.5">
+                    <span className="text-gray-600">Sign-up bonus <span className="text-gray-400">(amortized)</span></span>
+                    <span className="font-medium text-gray-800">+{formatCurrency(bd.sign_up_bonus_contribution)}/yr</span>
+                  </div>
+                )}
+                <div className="flex justify-between items-center px-3 py-2 bg-white rounded-b-lg font-semibold">
+                  <span className="text-gray-700">Total</span>
+                  <span className="text-[#1e2021]">~{formatCurrency(rec.estimated_annual_value)}/yr</span>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Meta row */}
@@ -594,8 +668,14 @@ function ResultCard({
           <span className="text-xs text-gray-500">Foreign transaction fee applies</span>
         )}
         {card.sign_up_bonus_value > 0 && (
-          <span className="text-xs text-gray-600">
+          <span className="relative group text-xs text-gray-600 cursor-default">
             <span className="font-medium">Sign-up bonus:</span> ~{formatCurrency(card.sign_up_bonus_value)} value
+            {card.sign_up_bonus_spend > 0 && (
+              <span className="absolute bottom-full left-0 mb-1.5 z-10 hidden group-hover:block w-56 rounded-lg bg-gray-900 text-white text-xs px-3 py-2 shadow-lg leading-relaxed pointer-events-none">
+                Spend {formatCurrency(card.sign_up_bonus_spend)} in {card.sign_up_bonus_days} days to earn ~{formatCurrency(card.sign_up_bonus_value)} in rewards value.
+                <span className="block text-gray-400 mt-1">Amortized as +{formatCurrency(Math.round(card.sign_up_bonus_value / 3))}/yr in the estimate above.</span>
+              </span>
+            )}
           </span>
         )}
       </div>

--- a/lib/card-recommendations.ts
+++ b/lib/card-recommendations.ts
@@ -43,11 +43,24 @@ export interface CreditCard {
   active: boolean;
 }
 
+export interface ValueBreakdown {
+  dining: number;
+  travel: number;
+  groceries: number;
+  gas: number;
+  streaming: number;
+  transit: number;
+  other: number;
+  annual_fee_cost: number;       // negative number, e.g. -95
+  sign_up_bonus_contribution: number; // amortized 1/3 of bonus value
+}
+
 export interface CardRecommendation {
   card_id: string;
   score: number;
   estimated_annual_value: number; // in dollars
   reason: string; // one personalized sentence
+  value_breakdown: ValueBreakdown;
   upgrade_from?: string; // e.g. "vs your current average of $X back"
 }
 
@@ -61,14 +74,13 @@ const CREDIT_SCORE_MAP: Record<QuizAnswers["credit_score_bucket"], number> = {
 
 /**
  * Calculate the estimated annual value of a card for a given spend profile.
- * Returns net value in dollars after annual fee.
+ * Returns net value in dollars after annual fee, plus a per-category breakdown.
  */
-function calculateAnnualValue(card: CreditCard, spend: SpendProfile): number {
+function calculateAnnualValue(card: CreditCard, spend: SpendProfile): { total: number; breakdown: ValueBreakdown } {
   const rates = card.earn_rates;
   const cpp = Number(card.rewards_value_cpp);
 
-  // Map spend categories to earn_rates keys
-  const categorySpend: Array<[keyof SpendProfile, string]> = [
+  const cats: Array<[keyof SpendProfile & keyof ValueBreakdown, string]> = [
     ["dining", "dining"],
     ["travel", "travel"],
     ["groceries", "groceries"],
@@ -77,31 +89,30 @@ function calculateAnnualValue(card: CreditCard, spend: SpendProfile): number {
     ["transit", "transit"],
   ];
 
-  let annualRewards = 0;
-  for (const [spendKey, rateKey] of categorySpend) {
+  const breakdown: ValueBreakdown = {
+    dining: 0, travel: 0, groceries: 0, gas: 0, streaming: 0, transit: 0,
+    other: 0, annual_fee_cost: -card.annual_fee, sign_up_bonus_contribution: Math.round(card.sign_up_bonus_value / 3),
+  };
+
+  for (const [spendKey, rateKey] of cats) {
     const monthly = spend[spendKey] ?? 0;
     const rate = rates[rateKey] ?? rates["base"] ?? 1;
-    // monthly_spend × earn_rate × cpp / 100 × 12 months
-    annualRewards += monthly * rate * (cpp / 100) * 12;
+    breakdown[spendKey] = Math.round(monthly * rate * (cpp / 100) * 12);
   }
+  breakdown.other = Math.round((spend.other ?? 0) * (rates["base"] ?? 1) * (cpp / 100) * 12);
 
-  // "other" uses base rate
-  const baseRate = rates["base"] ?? 1;
-  annualRewards += (spend.other ?? 0) * baseRate * (cpp / 100) * 12;
+  const total =
+    breakdown.dining + breakdown.travel + breakdown.groceries + breakdown.gas +
+    breakdown.streaming + breakdown.transit + breakdown.other +
+    breakdown.annual_fee_cost + breakdown.sign_up_bonus_contribution;
 
-  // Subtract annual fee
-  const netValue = annualRewards - card.annual_fee;
-
-  // Add sign-up bonus value, weighted at 1/3 (penalized for one-time nature)
-  const bonusContribution = card.sign_up_bonus_value / 3;
-
-  return netValue + bonusContribution;
+  return { total, breakdown };
 }
 
 /**
  * Build a personalized one-sentence reason for recommending a card.
  */
-function buildReason(card: CreditCard, spend: SpendProfile, annualValue: number): string {
+function buildReason(card: CreditCard, spend: SpendProfile, annualValue: number, _breakdown?: ValueBreakdown): string {
   const rates = card.earn_rates;
   const cpp = Number(card.rewards_value_cpp);
 
@@ -180,13 +191,14 @@ export function getCardRecommendations(
 
   // Score each card
   const scored = eligible.map((card) => {
-    const annualValue = calculateAnnualValue(card, spend);
+    const { total: annualValue, breakdown } = calculateAnnualValue(card, spend);
     const reason = buildReason(card, spend, annualValue);
     return {
       card_id: card.id,
       score: annualValue,
       estimated_annual_value: Math.round(annualValue),
       reason,
+      value_breakdown: breakdown,
     } satisfies CardRecommendation;
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #251 — adds transparency to the card recommendations.

- **"How we get to ~$X/yr" expandable** on each card showing per-category annual earnings (e.g. Dining 3x → +$540/yr), annual fee deduction, and amortized sign-up bonus
- **Sign-up bonus hover tooltip** — hover over the sign-up bonus line to see "Spend $4,000 in 3 months to earn ~$750" plus a note explaining how it's amortized in the estimate

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)