### PR TITLE
fix(gmail): set email_scan_enabled=true on connect/reconnect

### DIFF
--- a/app/cards/page.tsx
+++ b/app/cards/page.tsx
@@ -965,10 +965,10 @@ function CardsPageInner() {
             Back
           </button>
         )}
-        <div className="flex items-center gap-2.5 mx-auto">
+        <a href="https://coconut-app.dev" className="flex items-center gap-2.5 mx-auto hover:opacity-80 transition-opacity">
           <img src="/brand/coconut-mark.jpg" alt="Coconut" className="w-6 h-6 rounded-md" />
           <span className="text-sm font-semibold text-gray-700">Coconut</span>
-        </div>
+        </a>
         <div className="w-12" />
       </div>
 

--- a/lib/google-auth.ts
+++ b/lib/google-auth.ts
@@ -56,6 +56,7 @@ export async function saveGmailTokens(
       refresh_token: tokens.refresh_token ? encryptToken(tokens.refresh_token) : "",
       token_expiry: tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null,
       email: email ?? null,
+      email_scan_enabled: true,
     },
     { onConflict: "clerk_user_id" }
   ).select().single();


### PR DESCRIPTION
## Summary

- `saveGmailTokens` never wrote `email_scan_enabled: true` to the upsert, so the column stayed `false` (DB default) after every fresh connect and reconnect
- The scan route checks this flag and returns `400 Email scanning is not enabled` — making the scan button broken immediately after connecting/reconnecting Gmail
- Also includes: Coconut logo on `/cards` links to `coconut-app.dev`

## Test plan
- [ ] Connect Gmail → scan should work immediately without the 400 error
- [ ] Disconnect + reconnect Gmail → scan still works
- [ ] Logo on /cards links to coconut-app.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)