### PR TITLE
fix(cards): QA audit P1+P2 fixes — session reset, tx cap, validation, detected cards UX

### DIFF
--- a/app/api/cards/analyze-coconut/route.ts
+++ b/app/api/cards/analyze-coconut/route.ts
@@ -97,22 +97,24 @@ export async function POST() {
     // Non-fatal — detection is best-effort
   }
 
-  // Check if this user already has a card_tool_session from today
+  // Reuse a session from the last 24h only if the user hasn't started the quiz yet
+  // (quiz_answers being set means they're mid-flow — overwriting would erase their progress)
   const { data: existingSession } = await db
     .from("card_tool_sessions")
     .select("id")
     .eq("clerk_user_id", effectiveUserId)
     .gte("created_at", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString())
+    .is("quiz_answers", null)
     .maybeSingle();
 
   let sessionId: string;
 
   if (existingSession) {
-    // Update existing session
+    // Update existing pre-quiz session with fresh spend data
     sessionId = (existingSession as { id: string }).id;
     await db
       .from("card_tool_sessions")
-      .update({ spend_summary: spendSummary, recommendations: null, quiz_answers: null })
+      .update({ spend_summary: spendSummary })
       .eq("id", sessionId);
   } else {
     // Create new session

--- a/app/api/cards/analyze-plaid/route.ts
+++ b/app/api/cards/analyze-plaid/route.ts
@@ -88,10 +88,12 @@ export async function POST(request: NextRequest) {
       raw_name?: string | null;
     }> = [];
 
+    // Cap at 5000 transactions — enough for accurate spend profiling, avoids Vercel 15s timeout
+    const MAX_TRANSACTIONS = 5000;
     let offset = 0;
     let totalTransactions = 1;
 
-    while (offset < totalTransactions) {
+    while (offset < totalTransactions && offset < MAX_TRANSACTIONS) {
       const txResp = await client.transactionsGet({
         access_token,
         start_date: fmt(startDate),
@@ -211,7 +213,7 @@ export async function POST(request: NextRequest) {
 
     sessionId = (session as { id: string }).id;
 
-    const response = NextResponse.json({ session_id: sessionId, spend_summary: finalSpendSummary, detected_card_ids: detectedCardIds });
+    const response = NextResponse.json({ session_id: sessionId, spend_summary: finalSpendSummary, detected_card_ids: detectedCardIds ?? [] });
     // Set httpOnly session cookie (30 days)
     response.cookies.set("card_session_id", sessionId, {
       httpOnly: true,

--- a/app/api/cards/recommend/route.ts
+++ b/app/api/cards/recommend/route.ts
@@ -36,6 +36,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "quiz_answers required" }, { status: 400 });
   }
 
+  // Validate required fields so the engine doesn't silently produce wrong results
+  const validBuckets = ["excellent", "good", "fair", "poor"];
+  if (
+    !Array.isArray(quizAnswers.countries) || quizAnswers.countries.length === 0 ||
+    typeof quizAnswers.max_annual_fee !== "number" ||
+    !Array.isArray(quizAnswers.networks) || quizAnswers.networks.length === 0 ||
+    !Array.isArray(quizAnswers.existing_cards) ||
+    typeof quizAnswers.is_business !== "boolean" ||
+    !validBuckets.includes(quizAnswers.credit_score_bucket)
+  ) {
+    return NextResponse.json({ error: "Invalid quiz_answers" }, { status: 400 });
+  }
+
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
   const rl = rateLimit(`cards-recommend:${ip}`, 20, 60_000);
   if (!rl.success) {

--- a/app/cards/page.tsx
+++ b/app/cards/page.tsx
@@ -424,9 +424,10 @@ interface SimpleCard {
 interface QuizStep3Props {
   value: string[];
   onChange: (v: string[]) => void;
+  detectedCardIds?: string[];
 }
 
-function Step3ExistingCards({ value, onChange }: QuizStep3Props) {
+function Step3ExistingCards({ value, onChange, detectedCardIds = [] }: QuizStep3Props) {
   const [cards, setCards] = useState<SimpleCard[]>([]);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
@@ -483,6 +484,16 @@ function Step3ExistingCards({ value, onChange }: QuizStep3Props) {
           className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1e2021]/20"
         />
       </div>
+      {/* Detected cards banner */}
+      {detectedCardIds.length > 0 && !loading && (
+        <div className="mb-3 p-3 rounded-xl bg-blue-50 border border-blue-100 text-xs text-blue-800">
+          <p className="font-semibold mb-1">
+            We detected {detectedCardIds.length} card{detectedCardIds.length > 1 ? "s" : ""} from your connected bank — pre-selected below.
+          </p>
+          <p className="text-blue-600">Deselect any you don{"'"}t actually have.</p>
+        </div>
+      )}
+
       {loading ? (
         <div className="flex justify-center py-8">
           <Loader2 size={20} className="animate-spin text-gray-400" />
@@ -511,7 +522,12 @@ function Step3ExistingCards({ value, onChange }: QuizStep3Props) {
                     className={`w-full flex items-center justify-between px-3 py-2.5 hover:bg-gray-50 transition-colors text-left ${selected ? "bg-blue-50" : ""}`}
                   >
                     <div>
-                      <p className="text-sm font-medium text-gray-900">{card.name}</p>
+                      <p className="text-sm font-medium text-gray-900">
+                        {card.name}
+                        {detectedCardIds.includes(card.id) && (
+                          <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-700">detected</span>
+                        )}
+                      </p>
                       <p className="text-xs text-gray-500">
                         {card.annual_fee === 0 ? "No annual fee" : `$${card.annual_fee}/yr`} · {NETWORK_LABELS[card.network] ?? card.network}
                       </p>
@@ -835,6 +851,8 @@ function CardsPageInner() {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [spendSummary, setSpendSummary] = useState<SpendSummary | null>(null);
   const [banksConnected, setBanksConnected] = useState(0);
+  // IDs that were auto-detected from Plaid/Coconut accounts — shown as a hint in Step 3
+  const [autoDetectedCardIds, setAutoDetectedCardIds] = useState<string[]>([]);
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [allCardsMap, setAllCardsMap] = useState<Map<string, CardData>>(new Map());
   const [error, setError] = useState<string | null>(null);
@@ -883,8 +901,9 @@ function CardsPageInner() {
       }
       setSessionId(data.session_id);
       setSpendSummary(data.spend_summary);
-      // Always overwrite existingCards so stale detections from a prior session don't persist
-      setExistingCards(data.detected_card_ids ?? []);
+      const detected = data.detected_card_ids ?? [];
+      setAutoDetectedCardIds(detected);
+      setExistingCards(detected);
       setStage("quiz");
     } catch {
       setError("Failed to connect. Please try again.");
@@ -895,17 +914,18 @@ function CardsPageInner() {
   const handlePlaidSuccess = (sid: string, summary: SpendSummary, detectedCardIds?: string[]) => {
     setSessionId(sid);
     setSpendSummary(summary);
-    // Always overwrite existingCards so stale detections from a prior session don't persist
-    setExistingCards(detectedCardIds ?? []);
+    const detected = detectedCardIds ?? [];
+    setAutoDetectedCardIds(detected);
+    setExistingCards(detected);
     setBanksConnected(1);
     setStage("quiz");
   };
 
   const handleAddBankSuccess = (_sid: string, summary: SpendSummary, detectedCardIds?: string[]) => {
-    // Server already merged spend; update state with merged result
     setSpendSummary(summary);
-    // Merge detected card IDs (union of both banks)
-    setExistingCards((prev) => Array.from(new Set([...prev, ...(detectedCardIds ?? [])])));
+    const newDetected = detectedCardIds ?? [];
+    setAutoDetectedCardIds((prev) => Array.from(new Set([...prev, ...newDetected])));
+    setExistingCards((prev) => Array.from(new Set([...prev, ...newDetected])));
     setBanksConnected((n) => n + 1);
   };
 
@@ -990,7 +1010,14 @@ function CardsPageInner() {
               if (quizStep > 0) {
                 setQuizStep((s) => s - 1);
               } else {
+                // Reset all session state so a fresh Plaid connect starts clean
                 setStage("entry");
+                setSessionId(null);
+                setSpendSummary(null);
+                setExistingCards([]);
+                setAutoDetectedCardIds([]);
+                setBanksConnected(0);
+                setQuizStep(0);
               }
             }}
             className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-800 transition-colors"
@@ -1114,7 +1141,7 @@ function CardsPageInner() {
                 <Step2Networks value={networks} onChange={setNetworks} />
               )}
               {quizStep === 3 && (
-                <Step3ExistingCards value={existingCards} onChange={setExistingCards} />
+                <Step3ExistingCards value={existingCards} onChange={setExistingCards} detectedCardIds={autoDetectedCardIds} />
               )}
               {quizStep === 4 && (
                 <Step4PersonalBusiness value={isBusiness} onChange={setIsBusiness} />


### PR DESCRIPTION
## Summary

QA audit found 3 P1 and 4 P2 issues. All fixed.

## P1 — Critical

**Session not reset on back navigation**
Going back from quiz step 0 to entry left `sessionId`/`spendSummary`/`banksConnected` populated. A second Plaid connect would create a new session but the old stale cookie was still set, causing a merge into the wrong session.
Fix: back button now resets all session state.

**analyze-coconut overwrites in-progress sessions**
Re-triggering `?coconut=1` while on quiz step 4/5 would find the same 24h session and overwrite `quiz_answers` and `recommendations` with null, erasing progress.
Fix: only reuse session if `quiz_answers IS NULL` (quiz not started yet).

**Unbounded Plaid transaction fetch loop**
Users with thousands of transactions hit Vercel's 15s serverless limit. The while loop had no upper bound.
Fix: cap at 5,000 transactions — more than enough for spend profiling.

## P2 — Notable

**quiz_answers not validated in recommend route**
Only existence checked, not field validity. Empty `countries`/`networks` arrays or invalid `credit_score_bucket` would silently produce wrong results.
Fix: added field-level validation returning 400 for invalid inputs.

**`detected_card_ids` could return `undefined`**
Detection is wrapped in try/catch; on failure the variable stays uninitialized. Now always returns `[]`.

**Detected cards not visually surfaced in Step 3**
Auto-detected cards were pre-selected in state but users had no way to know — they'd scroll through 70+ cards with no indication. 
Fix: "We detected N cards from your connected bank" banner at top of Step 3 + "detected" badge on each card.

**`autoDetectedCardIds` tracked separately**
So the detection hint persists across quiz navigation even as `existingCards` changes.

## Test plan
- [ ] Connect bank → quiz → back to entry → connect bank again → should start fresh (no merge)
- [ ] `?coconut=1` while on quiz step 4 → refresh → quiz progress preserved
- [ ] Connect bank with many transactions → analyze-plaid completes in < 15s
- [ ] Step 3 with detected cards shows banner + badges
- [ ] Submit quiz with empty networks array via API → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)