### PR TITLE
fix: bug council audit — 1 bug fixed

### DIFF
--- a/app/api/cards/analyze-coconut/route.ts
+++ b/app/api/cards/analyze-coconut/route.ts
@@ -54,8 +54,11 @@ export async function POST() {
     return NextResponse.json({ error: "Failed to fetch transactions" }, { status: 500 });
   }
 
+  // Coconut DB stores expenses as negative amounts; categorizeTransactions()
+  // follows Plaid convention (positive = expense) and skips amounts <= 0.
+  // Negate to convert DB sign convention → Plaid sign convention.
   const rows = (transactions ?? []).map((tx) => ({
-    amount: tx.amount as number,
+    amount: -(tx.amount as number),
     primary_category: tx.primary_category as string | null,
     detailed_category: tx.detailed_category as string | null,
     merchant_name: tx.merchant_name as string | null,

--- a/lib/__tests__/card-recommendations.test.ts
+++ b/lib/__tests__/card-recommendations.test.ts
@@ -359,3 +359,59 @@ describe("categorizeTransactions", () => {
     expect(result.total).toBe(300);
   });
 });
+
+// ── BUG-CRITICAL-1: Coconut DB sign convention (analyze-coconut route) ────────
+//
+// Coconut DB stores expenses as NEGATIVE amounts. categorizeTransactions()
+// follows Plaid convention (positive = expense) and guards `if (tx.amount <= 0) continue`.
+// The analyze-coconut route MUST negate amounts before calling categorizeTransactions(),
+// otherwise every expense is skipped and the spend summary is all zeros.
+
+describe("categorizeTransactions — Coconut DB sign convention (BUG-CRITICAL-1)", () => {
+  it("returns all-zero spend when DB amounts are passed without negation (demonstrates the bug)", () => {
+    // Simulate what analyze-coconut route did BEFORE the fix:
+    // DB rows have negative amounts, passed directly without negation.
+    const dbRows = [
+      { amount: -60, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS" },
+      { amount: -200, primary_category: "GROCERIES", detailed_category: "SUPERMARKET" },
+      { amount: -80, primary_category: "TRANSPORTATION", detailed_category: "GAS_AND_FUEL" },
+    ];
+    const result = categorizeTransactions(dbRows, 1);
+    // All amounts are <= 0, so they are all skipped — zero spend profile
+    expect(result.dining).toBe(0);
+    expect(result.groceries).toBe(0);
+    expect(result.gas).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("produces correct non-zero spend when DB amounts are negated before categorization (verifies the fix)", () => {
+    // Simulate what analyze-coconut route does AFTER the fix:
+    // DB rows have negative amounts, negated to positive before categorization.
+    const dbRows = [
+      { amount: -60, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS" },
+      { amount: -200, primary_category: "GROCERIES", detailed_category: "SUPERMARKET" },
+      { amount: -80, primary_category: "TRANSPORTATION", detailed_category: "GAS_AND_FUEL" },
+    ];
+    const negatedRows = dbRows.map((tx) => ({ ...tx, amount: -(tx.amount) }));
+    const result = categorizeTransactions(negatedRows, 1);
+    expect(result.dining).toBe(60);
+    expect(result.groceries).toBe(200);
+    expect(result.gas).toBe(80);
+    expect(result.total).toBe(340);
+  });
+
+  it("correctly divides negated DB amounts by months_analyzed", () => {
+    // 3 months of DB transactions — each expense is negative
+    const dbRows = [
+      { amount: -300, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS" },
+      { amount: -600, primary_category: "GROCERIES", detailed_category: "SUPERMARKET" },
+    ];
+    const negatedRows = dbRows.map((tx) => ({ ...tx, amount: -(tx.amount) }));
+    const result = categorizeTransactions(negatedRows, 3);
+    // 300 / 3 = 100 dining/month, 600 / 3 = 200 groceries/month
+    expect(result.dining).toBe(100);
+    expect(result.groceries).toBe(200);
+    expect(result.total).toBe(300);
+    expect(result.months_analyzed).toBe(3);
+  });
+});


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 2 distinct (BUG-A: sign convention × 5 agents, BUG-B: auto-open guard × 3 agents)
**Bugs verified (survived Devil's Advocate)**: 1
**Bugs fixed (with tests)**: 1
**Bugs deferred**: 0
**False positives rejected**: 1

## Fixed Bugs

### P1 — Broken Functionality

**BUG-CRITICAL-1**: `analyze-coconut` produces all-zero spend profiles for every Coconut user — `app/api/cards/analyze-coconut/route.ts` (test: `lib/__tests__/card-recommendations.test.ts`)

Coconut DB stores purchase amounts as **negative** values (enforced in `transaction-sync.ts`: expenses are negated on Plaid ingest). The `analyze-coconut` route passed DB rows directly to `categorizeTransactions()`, which guards `if (tx.amount <= 0) continue` — skipping every expense. The result was an all-zero spend summary for every authenticated Coconut user, making card recommendations meaningless (all cards ranked by sign-up bonus only, ignoring actual spend behavior).

Fix: negate the DB amount in the row mapping: `amount: -(tx.amount as number)`.

## Tests Added

- `lib/__tests__/card-recommendations.test.ts` — 3 new tests in `"categorizeTransactions — Coconut DB sign convention (BUG-CRITICAL-1)"`:
  1. Demonstrates the bug: raw negative DB amounts produce zero spend (dining=0, groceries=0)
  2. Verifies the fix: negated amounts produce correct spend (dining=60, groceries=200)
  3. Monthly average with negated amounts divides correctly by `months_analyzed`

## Disproved Bugs (Rejected by Devil's Advocate)

- **BUG-B**: Auto-open Plaid Link fires after migration sets `step = "connected"` — **DISPROVED**: The `fromApp` render-path already early-returns `<ConnectedStep>` when `step === "connected"`, and the `!linkToken` guard in the auto-open effect additionally blocks it if migration wins the race before the link-token fetch completes.

## Patterns Found

- Sign convention mismatch (`analyze-coconut` passing negative DB amounts to `categorizeTransactions`) — **4th occurrence** of this pattern class across audits. Already documented in `.cursor/rules/common-bugs.mdc` line 18; no update needed.

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (no new errors vs baseline)
- [x] `npm run test` — passes (618 tests, +3 new, all green; baseline was 615)

---
Generated by Bug Council v2 (evidence-based)