### PR TITLE
fix: bug council audit — 4 bugs fixed

### DIFF
--- a/app/api/cards/analyze-coconut/__tests__/route.test.ts
+++ b/app/api/cards/analyze-coconut/__tests__/route.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for POST /api/cards/analyze-coconut
+ *
+ * BUG-CRITICAL-1: DB amounts must be negated before passing to categorizeTransactions().
+ *   Coconut DB stores expenses as NEGATIVE (e.g. -50 for a $50 charge).
+ *   categorizeTransactions() skips amounts <= 0. Without negation, all spend is filtered
+ *   out and the returned spend_summary is all zeros.
+ *
+ * BUG-RESILIENCE-1: .update() result must destructure { error } and return HTTP 500 on failure.
+ *   Without this, a DB update failure silently returns HTTP 200 with stale spend data.
+ */
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/auth", () => ({
+  loadClerkAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/demo", () => ({
+  getEffectiveUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { loadClerkAuth } from "@/lib/auth";
+import { getEffectiveUserId } from "@/lib/demo";
+import { rateLimit } from "@/lib/rate-limit";
+import { getSupabaseAdmin } from "@/lib/supabase";
+
+const mockLoadClerkAuth = vi.mocked(loadClerkAuth);
+const mockGetEffectiveUserId = vi.mocked(getEffectiveUserId);
+const mockRateLimit = vi.mocked(rateLimit);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+import { POST } from "../route";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Builds a chainable Supabase query mock that resolves to `result`. */
+function makeQuery(result: unknown) {
+  const q: Record<string, unknown> = {};
+  const chain = [
+    "select", "eq", "is", "gte", "lte", "not", "order",
+    "limit", "in", "update", "insert", "maybeSingle", "single",
+  ];
+  chain.forEach((method) => {
+    q[method] = vi.fn(() => q);
+  });
+  // Terminal calls that should resolve
+  (q["maybeSingle"] as ReturnType<typeof vi.fn>).mockResolvedValue(result);
+  (q["single"] as ReturnType<typeof vi.fn>).mockResolvedValue(result);
+  // Allow .limit(), .lte() etc. to also resolve (for the transactions fetch)
+  (q["limit"] as ReturnType<typeof vi.fn>).mockResolvedValue(result);
+  return q;
+}
+
+/**
+ * Build a minimal Supabase db mock where:
+ *  - `transactions` table returns the provided rows
+ *  - `accounts` / `credit_cards` / `plaid_items` return empty arrays (no card detection)
+ *  - `card_tool_sessions` behaves as specified by `sessionOpts`
+ */
+function makeDb(opts: {
+  transactions: Array<{
+    amount: number;
+    primary_category: string | null;
+    detailed_category: string | null;
+    merchant_name: string | null;
+    raw_name: string | null;
+  }>;
+  existingSession?: { id: string } | null;
+  updateError?: { message: string } | null;
+  insertResult?: { data: { id: string } | null; error: { message: string } | null };
+}) {
+  const {
+    transactions,
+    existingSession = null,
+    updateError = null,
+    insertResult = { data: { id: "new-session-id" }, error: null },
+  } = opts;
+
+  // Build per-table behaviour
+  const txQuery = makeQuery({ data: transactions, error: null });
+
+  const accountsQuery = makeQuery({ data: [], error: null });
+  const creditCardsQuery = makeQuery({ data: [], error: null });
+  const plaidItemsQuery = makeQuery({ data: [], error: null });
+
+  // card_tool_sessions — maybeSingle returns existing session (or null)
+  const sessionSelectQuery = makeQuery({ data: existingSession, error: null });
+
+  // card_tool_sessions — update: route does .update({}).eq("id", id)
+  // .eq() is the terminal call — mock it to resolve with { error }
+  const updateQuery = makeQuery({ data: null, error: updateError });
+  (updateQuery["eq"] as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: updateError });
+
+  // card_tool_sessions — insert
+  const insertQuery = makeQuery(insertResult);
+  (insertQuery["select"] as ReturnType<typeof vi.fn>).mockReturnValue(insertQuery);
+  (insertQuery["single"] as ReturnType<typeof vi.fn>).mockResolvedValue(insertResult);
+
+  const db = {
+    from: vi.fn((table: string) => {
+      if (table === "transactions") return txQuery;
+      if (table === "accounts") return accountsQuery;
+      if (table === "credit_cards") return creditCardsQuery;
+      if (table === "plaid_items") return plaidItemsQuery;
+      if (table === "card_tool_sessions") {
+        // Return different sub-mocks for select vs update vs insert
+        return {
+          select: vi.fn(() => sessionSelectQuery),
+          update: vi.fn(() => updateQuery),
+          insert: vi.fn(() => insertQuery),
+        };
+      }
+      return makeQuery({ data: null, error: null });
+    }),
+  };
+  return db;
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockLoadClerkAuth.mockResolvedValue({
+    ok: true,
+    userId: "clerk_user_test",
+  } as Awaited<ReturnType<typeof loadClerkAuth>>);
+
+  mockGetEffectiveUserId.mockResolvedValue("effective_user_test");
+
+  mockRateLimit.mockReturnValue({ success: true, remaining: 9, reset: Date.now() + 60_000 });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── BUG-CRITICAL-1 tests ─────────────────────────────────────────────────────
+
+describe("BUG-CRITICAL-1: DB amounts negated before categorization", () => {
+  it("produces non-zero dining spend when DB returns negative amounts", async () => {
+    /**
+     * This test FAILS against the old code (amount: tx.amount) because
+     * categorizeTransactions() skips amounts <= 0, so all DB expense rows
+     * (stored as negatives) are filtered and spend_summary is all zeros.
+     *
+     * With the fix (amount: -(tx.amount)), the negated positive value passes
+     * the guard and dining spend is correctly counted.
+     */
+    const db = makeDb({
+      transactions: [
+        {
+          amount: -60,
+          primary_category: "FOOD_AND_DRINK",
+          detailed_category: "RESTAURANTS",
+          merchant_name: "Burger Place",
+          raw_name: "BURGER PLACE",
+        },
+      ],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    // With 3 months analyzed and $60 total dining, monthly average = $20
+    expect(json.spend_summary.dining).toBeGreaterThan(0);
+    expect(json.spend_summary.dining).toBe(20); // 60 / 3 months
+  });
+
+  it("produces all-zero spend when DB returns zero-amount transactions (no negation involved)", async () => {
+    // Baseline: zero amounts should still produce zero spend regardless
+    const db = makeDb({
+      transactions: [
+        {
+          amount: 0,
+          primary_category: "FOOD_AND_DRINK",
+          detailed_category: "RESTAURANTS",
+          merchant_name: null,
+          raw_name: null,
+        },
+      ],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.spend_summary.dining).toBe(0);
+  });
+
+  it("correctly classifies multiple negative-amount DB rows across categories", async () => {
+    /**
+     * Verifies that negation works for all categories, not just dining.
+     * Old code: all filtered → all zeros.
+     * Fixed code: negated → correct monthly averages.
+     */
+    const db = makeDb({
+      transactions: [
+        { amount: -300, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS", merchant_name: null, raw_name: null },
+        { amount: -150, primary_category: "GROCERIES", detailed_category: "SUPERMARKET", merchant_name: null, raw_name: null },
+        { amount: -600, primary_category: "TRAVEL", detailed_category: "AIRLINES", merchant_name: null, raw_name: null },
+      ],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    const json = await res.json();
+
+    // 3-month window → divide totals by 3
+    expect(json.spend_summary.dining).toBe(100);   // 300 / 3
+    expect(json.spend_summary.groceries).toBe(50); // 150 / 3
+    expect(json.spend_summary.travel).toBe(200);   // 600 / 3
+  });
+
+  it("session_id is present in response when spend profile is non-zero", async () => {
+    const db = makeDb({
+      transactions: [
+        { amount: -90, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS", merchant_name: null, raw_name: null },
+      ],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    const json = await res.json();
+    expect(json.session_id).toBeDefined();
+    expect(typeof json.session_id).toBe("string");
+  });
+});
+
+// ── BUG-RESILIENCE-1 tests ───────────────────────────────────────────────────
+
+describe("BUG-RESILIENCE-1: DB update error surfaces as HTTP 500", () => {
+  it("returns 500 when the card_tool_sessions update fails", async () => {
+    /**
+     * This test FAILS against the old code because the old code does `await db.update()`
+     * without destructuring { error }, so updateError is never checked and the route
+     * returns HTTP 200 as if everything succeeded.
+     *
+     * With the fix (destructure { error: updateError } and return 500 on truthy),
+     * this correctly returns 500.
+     */
+    const db = makeDb({
+      transactions: [
+        { amount: -50, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS", merchant_name: null, raw_name: null },
+      ],
+      existingSession: { id: "existing-session-abc" },
+      updateError: { message: "DB connection timeout" },
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to update session");
+  });
+
+  it("returns 200 when the card_tool_sessions update succeeds", async () => {
+    // Confirms the success path is unaffected by the fix
+    const db = makeDb({
+      transactions: [
+        { amount: -50, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS", merchant_name: null, raw_name: null },
+      ],
+      existingSession: { id: "existing-session-abc" },
+      updateError: null, // no error
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session_id).toBe("existing-session-abc");
+  });
+
+  it("returns 200 via insert path when no existing session and insert succeeds", async () => {
+    // Verifies insert path (no existing session) is unaffected
+    const db = makeDb({
+      transactions: [
+        { amount: -30, primary_category: "GROCERIES", detailed_category: "SUPERMARKET", merchant_name: null, raw_name: null },
+      ],
+      existingSession: null,
+      insertResult: { data: { id: "brand-new-session" }, error: null },
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session_id).toBe("brand-new-session");
+  });
+});

--- a/app/api/cards/analyze-coconut/__tests__/route.test.ts
+++ b/app/api/cards/analyze-coconut/__tests__/route.test.ts
@@ -137,7 +137,7 @@ beforeEach(() => {
 
   mockGetEffectiveUserId.mockResolvedValue("effective_user_test");
 
-  mockRateLimit.mockReturnValue({ success: true, remaining: 9, reset: Date.now() + 60_000 });
+  mockRateLimit.mockReturnValue({ success: true, remaining: 9 });
 });
 
 afterEach(() => {
@@ -167,7 +167,7 @@ describe("BUG-CRITICAL-1: DB amounts negated before categorization", () => {
         },
       ],
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     expect(res.status).toBe(200);
@@ -191,7 +191,7 @@ describe("BUG-CRITICAL-1: DB amounts negated before categorization", () => {
         },
       ],
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     expect(res.status).toBe(200);
@@ -212,7 +212,7 @@ describe("BUG-CRITICAL-1: DB amounts negated before categorization", () => {
         { amount: -600, primary_category: "TRAVEL", detailed_category: "AIRLINES", merchant_name: null, raw_name: null },
       ],
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     const json = await res.json();
@@ -229,7 +229,7 @@ describe("BUG-CRITICAL-1: DB amounts negated before categorization", () => {
         { amount: -90, primary_category: "FOOD_AND_DRINK", detailed_category: "RESTAURANTS", merchant_name: null, raw_name: null },
       ],
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     const json = await res.json();
@@ -257,7 +257,7 @@ describe("BUG-RESILIENCE-1: DB update error surfaces as HTTP 500", () => {
       existingSession: { id: "existing-session-abc" },
       updateError: { message: "DB connection timeout" },
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     expect(res.status).toBe(500);
@@ -274,7 +274,7 @@ describe("BUG-RESILIENCE-1: DB update error surfaces as HTTP 500", () => {
       existingSession: { id: "existing-session-abc" },
       updateError: null, // no error
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     expect(res.status).toBe(200);
@@ -291,7 +291,7 @@ describe("BUG-RESILIENCE-1: DB update error surfaces as HTTP 500", () => {
       existingSession: null,
       insertResult: { data: { id: "brand-new-session" }, error: null },
     });
-    mockGetSupabaseAdmin.mockReturnValue(db as ReturnType<typeof getSupabaseAdmin>);
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await POST();
     expect(res.status).toBe(200);

--- a/app/api/cards/analyze-coconut/route.ts
+++ b/app/api/cards/analyze-coconut/route.ts
@@ -112,10 +112,14 @@ export async function POST() {
   if (existingSession) {
     // Update existing pre-quiz session with fresh spend data
     sessionId = (existingSession as { id: string }).id;
-    await db
+    const { error: updateError } = await db
       .from("card_tool_sessions")
       .update({ spend_summary: spendSummary })
       .eq("id", sessionId);
+    if (updateError) {
+      console.error("[cards/analyze-coconut] update error:", updateError.message);
+      return NextResponse.json({ error: "Failed to update session" }, { status: 500 });
+    }
   } else {
     // Create new session
     const { data: newSession, error: insertError } = await db

--- a/app/api/cards/analyze-coconut/route.ts
+++ b/app/api/cards/analyze-coconut/route.ts
@@ -55,7 +55,7 @@ export async function POST() {
   }
 
   const rows = (transactions ?? []).map((tx) => ({
-    amount: tx.amount as number,
+    amount: -(tx.amount as number),
     primary_category: tx.primary_category as string | null,
     detailed_category: tx.detailed_category as string | null,
     merchant_name: tx.merchant_name as string | null,

--- a/app/cards/page.tsx
+++ b/app/cards/page.tsx
@@ -437,7 +437,10 @@ function Step3ExistingCards({ value, onChange, detectedCardIds = [] }: QuizStep3
     setLoading(true);
     setFetchError(false);
     fetch("/api/cards/list")
-      .then((r) => r.json() as Promise<{ cards: SimpleCard[] }>)
+      .then((r) => {
+        if (!r.ok) throw new Error("failed");
+        return r.json() as Promise<{ cards: SimpleCard[] }>;
+      })
       .then((d) => setCards(d.cards ?? []))
       .catch(() => setFetchError(true))
       .finally(() => setLoading(false));

--- a/app/connect/page.tsx
+++ b/app/connect/page.tsx
@@ -450,6 +450,7 @@ function ConnectBankContent() {
 
   const hasAutoOpened = useRef(false);
   useEffect(() => {
+    if (step === "connected") return;
     if (!linkToken || !ready || hasAutoOpened.current) return;
     if (receivedRedirectUri || fromApp) {
       hasAutoOpened.current = true;
@@ -459,7 +460,7 @@ function ConnectBankContent() {
       });
       open();
     }
-  }, [receivedRedirectUri, linkToken, ready, open, logPlaidEvent, fromApp]);
+  }, [step, receivedRedirectUri, linkToken, ready, open, logPlaidEvent, fromApp]);
 
   if (fromApp) {
     if (step === "connected") {


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 5
**Bugs verified (survived Devil's Advocate)**: 4
**Bugs fixed (with tests)**: 4
**Bugs deferred**: 0
**False positives rejected**: 1

## Fixed Bugs

### P1 — Broken Functionality

**BUG-CRITICAL-1**: Sign convention regression — Coconut DB expense amounts not negated in `analyze-coconut` spend profile — `app/api/cards/analyze-coconut/route.ts` (test: `app/api/cards/analyze-coconut/__tests__/route.test.ts`)

PR #262 (`fix(cards): correct credit score thresholds`) accidentally reverted commit `d062a3b` which negated DB amounts before calling `categorizeTransactions()`. Coconut DB stores expenses as negative; `categorizeTransactions()` skips `amount <= 0`. Without the negation, ALL expenses are filtered out and every Coconut user gets an all-zero spend profile and meaningless card recommendations.

### P2 — Incorrect Behavior

**BUG-RESILIENCE-1**: `analyze-coconut` `.update()` DB error silently ignored — returns HTTP 200 even when spend_summary was not persisted — `app/api/cards/analyze-coconut/route.ts` (test: `app/api/cards/analyze-coconut/__tests__/route.test.ts`)

**BUG-ONBOARD-1**: Auto-open Plaid Link fires over "Bank connected" success screen — `app/connect/page.tsx` (untestable: React component with browser APIs)

When a `/cards` user token is auto-migrated (sets `step="connected"`), the parallel link-token fetch completing triggers the auto-open `useEffect` because `step` was missing from its dep array and the `if (step === "connected") return;` guard was absent.

**BUG-DAILY-1**: Missing `res.ok` check before `res.json()` in `/api/cards/list` fetch — `app/cards/page.tsx` (untestable: fetch inside React component)

A 500 response with JSON error body is silently parsed as `{ cards: undefined }`, showing empty card list instead of error state.

## Tests Added

- `app/api/cards/analyze-coconut/__tests__/route.test.ts` — 7 new tests covering:
  - BUG-CRITICAL-1: negative DB amounts produce non-zero spend (regression guard)
  - BUG-RESILIENCE-1: DB update failure returns HTTP 500 (not silent 200)
  - Success/insert path coverage (unaffected by fixes)

## Disproved Bugs (Rejected by Devil's Advocate)

- **BUG-CRITICAL-2**: Alleged IDOR in `/api/cards/recommend` — DISPROVED. Session ID is read exclusively from an httpOnly cookie set by the server (PR #256 fix). No user-controlled input path exists.

## Patterns Found

This audit triggered 3 previously catalogued patterns (all already in `.cursor/rules/common-bugs.mdc`):
- **Sign convention** (Coconut negative → Plaid positive) — appeared for the 4th time across audits; PR #262 regression
- **Supabase update error swallowing** — established Pattern #1
- **Auto-open useEffect missing step guard** — established Pattern #10; appeared for the 3rd time

No new patterns added (threshold: 3+ occurrences to add, all already catalogued).

## Verification
- [x] `npm run typecheck` — passes (0 new errors vs baseline)
- [x] `npm run lint` — passes (70 warnings, same as baseline, 0 errors)
- [x] `npm run test` — passes (622 tests, +7 vs baseline of 615, all green)

---
Generated by Bug Council v2 (evidence-based)