### PR TITLE
fix: bug council audit — 2 bugs fixed

### DIFF
--- a/app/api/cards/__tests__/migrate-token.test.ts
+++ b/app/api/cards/__tests__/migrate-token.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for POST /api/cards/migrate-token
+ *
+ * BUG-CRITICAL-1: Missing session ownership check.
+ *   The route loaded a card_tool_sessions row by cookie but never verified
+ *   that the session's clerk_user_id matched the currently authenticated user.
+ *   A second user on the same machine (30-day httpOnly cookie) could have
+ *   another Coconut user's Plaid token migrated into their account.
+ *
+ *   Fix: select clerk_user_id, then reject with 403 when
+ *        clerk_user_id IS NOT NULL and does NOT match effectiveUserId.
+ *
+ *   Sessions created unauthenticated (analyze-plaid) have clerk_user_id = NULL
+ *   and are intentionally claimable by any user who holds the cookie.
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/auth", () => ({
+  loadClerkAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/demo", () => ({
+  getEffectiveUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decryptToken: vi.fn((t: string) => `decrypted:${t}`),
+}));
+
+vi.mock("@/lib/transaction-sync", () => ({
+  savePlaidToken: vi.fn().mockResolvedValue(undefined),
+  syncTransactionsForUser: vi.fn().mockResolvedValue({ synced: 0 }),
+  embedTransactionsForUser: vi.fn().mockResolvedValue(undefined),
+  embedRichTransactionsForUser: vi.fn().mockResolvedValue(undefined),
+  enrichCategoriesForUser: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/cached-queries", () => ({
+  CACHE_TAGS: {
+    transactions: (id: string) => `tx-${id}`,
+  },
+}));
+
+// next/headers — mock cookies() so the route can read card_session_id
+const mockCookieGet = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() =>
+    Promise.resolve({
+      get: mockCookieGet,
+    })
+  ),
+}));
+
+// plaid-client — not needed for ownership-check tests; keep it absent so the
+// dynamic import returns null (the route falls back to savePlaidToken directly)
+vi.mock("@/lib/plaid-client", () => ({
+  getPlaidClient: vi.fn(() => null),
+}));
+
+import { loadClerkAuth } from "@/lib/auth";
+import { getEffectiveUserId } from "@/lib/demo";
+import { rateLimit } from "@/lib/rate-limit";
+import { getSupabaseAdmin } from "@/lib/supabase";
+
+const mockLoadClerkAuth = vi.mocked(loadClerkAuth);
+const mockGetEffectiveUserId = vi.mocked(getEffectiveUserId);
+const mockRateLimit = vi.mocked(rateLimit);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+import { POST } from "../migrate-token/route";
+
+// ── DB mock helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Builds a minimal Supabase db mock for the card_tool_sessions table.
+ * `sessionRow` is what maybeSingle() resolves to (or null for "not found").
+ */
+function makeDb(sessionRow: Record<string, unknown> | null) {
+  const sessionResult = { data: sessionRow, error: null };
+
+  const sessionSelectQuery = {
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(sessionResult),
+  };
+
+  const updateQuery = {
+    eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+
+  const plaidItemsQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+
+  const db = {
+    from: vi.fn((table: string) => {
+      if (table === "card_tool_sessions") {
+        return {
+          select: vi.fn(() => sessionSelectQuery),
+          update: vi.fn(() => updateQuery),
+        };
+      }
+      if (table === "plaid_items") {
+        return plaidItemsQuery;
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+  };
+  return db;
+}
+
+/** Shared future expiry timestamp (well beyond any test run). */
+const FUTURE_EXPIRY = new Date(Date.now() + 1_000_000_000).toISOString();
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockLoadClerkAuth.mockResolvedValue({
+    ok: true,
+    userId: "clerk_attacker",
+  } as Awaited<ReturnType<typeof loadClerkAuth>>);
+
+  mockGetEffectiveUserId.mockResolvedValue("effective_attacker");
+
+  mockRateLimit.mockReturnValue({ success: true, remaining: 4 });
+
+  // Default: cookie is present
+  mockCookieGet.mockImplementation((name: string) =>
+    name === "card_session_id" ? { value: "session-abc" } : undefined
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── BUG-CRITICAL-1 tests ──────────────────────────────────────────────────────
+
+describe("BUG-CRITICAL-1: session ownership check in migrate-token", () => {
+  it("returns 403 when the session was created by a different Coconut user (clerk_user_id mismatch)", async () => {
+    /**
+     * This is the core security test.
+     *
+     * A session created by "effective_owner" (an authenticated Coconut user)
+     * has clerk_user_id = "effective_owner". A different user ("effective_attacker")
+     * holds the 30-day cookie and calls this route.
+     *
+     * OLD code (bug): clerk_user_id was not selected and not checked — the route
+     *   would proceed to savePlaidToken and migrate the token into the attacker's
+     *   account, returning { ok: true }.
+     *
+     * FIXED code: clerk_user_id is selected; the mismatch check fires and returns
+     *   { ok: false, reason: "session_not_owned" } with HTTP 403.
+     */
+    const db = makeDb({
+      id: "session-abc",
+      plaid_access_token: "enc-token",
+      plaid_item_id: "item-xyz",
+      converted_to_clerk_user_id: null,
+      expires_at: FUTURE_EXPIRY,
+      clerk_user_id: "effective_owner", // belongs to a DIFFERENT user
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    // Current user is the attacker, NOT the owner
+    mockGetEffectiveUserId.mockResolvedValue("effective_attacker");
+
+    const res = await POST();
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.reason).toBe("session_not_owned");
+  });
+
+  it("allows migration when clerk_user_id is NULL (unauthenticated / analyze-plaid session)", async () => {
+    /**
+     * Sessions created via the unauthenticated /cards flow (analyze-plaid) have
+     * clerk_user_id = NULL. Any authenticated user who holds the cookie should
+     * be able to claim and migrate such a session — this is the intended path.
+     */
+    const db = makeDb({
+      id: "session-abc",
+      plaid_access_token: "enc-token",
+      plaid_item_id: "item-xyz",
+      converted_to_clerk_user_id: null,
+      expires_at: FUTURE_EXPIRY,
+      clerk_user_id: null, // unauthenticated session — claimable by anyone
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    mockGetEffectiveUserId.mockResolvedValue("effective_attacker");
+
+    const res = await POST();
+
+    // Must NOT be a 403 — the session is unowned and claimable
+    expect(res.status).not.toBe(403);
+    // Should succeed
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.item_id).toBe("item-xyz");
+  });
+
+  it("allows migration when clerk_user_id matches the current user (same owner)", async () => {
+    /**
+     * The session belongs to the same user who is calling the route.
+     * The ownership check must pass and migration must proceed normally.
+     */
+    const db = makeDb({
+      id: "session-abc",
+      plaid_access_token: "enc-token",
+      plaid_item_id: "item-xyz",
+      converted_to_clerk_user_id: null,
+      expires_at: FUTURE_EXPIRY,
+      clerk_user_id: "effective_owner", // same as the current user below
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    mockGetEffectiveUserId.mockResolvedValue("effective_owner"); // same as session owner
+
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.item_id).toBe("item-xyz");
+  });
+
+  it("returns session_not_owned (403) even when the session has a valid token and has not expired", async () => {
+    /**
+     * Guards against a subtle regression: make sure the ownership check runs
+     * BEFORE the expensive decrypt/savePlaidToken path, not just before expiry.
+     * The session is fully valid in every other way — only the user mismatch matters.
+     */
+    const db = makeDb({
+      id: "session-abc",
+      plaid_access_token: "enc-token",
+      plaid_item_id: "item-xyz",
+      converted_to_clerk_user_id: null,
+      expires_at: FUTURE_EXPIRY,
+      clerk_user_id: "some_other_user",
+    });
+    mockGetSupabaseAdmin.mockReturnValue(db as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    mockGetEffectiveUserId.mockResolvedValue("entirely_different_user");
+
+    const res = await POST();
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.reason).toBe("session_not_owned");
+  });
+});

--- a/app/api/cards/migrate-token/route.ts
+++ b/app/api/cards/migrate-token/route.ts
@@ -55,7 +55,7 @@ export async function POST() {
   // Load the card tool session — must have a plaid token and must not already be migrated
   const { data: cardSession, error: sessionError } = await db
     .from("card_tool_sessions")
-    .select("id, plaid_access_token, plaid_item_id, converted_to_clerk_user_id, expires_at")
+    .select("id, plaid_access_token, plaid_item_id, converted_to_clerk_user_id, expires_at, clerk_user_id")
     .eq("id", sessionId)
     .maybeSingle();
 
@@ -69,6 +69,7 @@ export async function POST() {
     plaid_item_id: string | null;
     converted_to_clerk_user_id: string | null;
     expires_at: string;
+    clerk_user_id: string | null;
   };
 
   // Nothing to migrate — session has no Plaid token (manual-entry or coconut path)
@@ -84,6 +85,14 @@ export async function POST() {
   // Session expired
   if (new Date(cs.expires_at) < new Date()) {
     return NextResponse.json({ ok: false, reason: "session_expired" });
+  }
+
+  // Ownership check: sessions created by an authenticated Coconut user have
+  // clerk_user_id set and must only be migrated by that same user.
+  // Sessions created unauthenticated (analyze-plaid) have clerk_user_id = NULL
+  // and are intentionally claimable by any user who holds the cookie.
+  if (cs.clerk_user_id !== null && cs.clerk_user_id !== effectiveUserId) {
+    return NextResponse.json({ ok: false, reason: "session_not_owned" }, { status: 403 });
   }
 
   // Decrypt the stored token

--- a/app/app/subscriptions/__tests__/page.test.ts
+++ b/app/app/subscriptions/__tests__/page.test.ts
@@ -1,0 +1,69 @@
+/**
+ * BUG-DAILY-1: Subscription amounts must be converted from USD to the user's
+ * display currency before formatting, not just have the currency symbol swapped.
+ *
+ * The subscriptions page previously called fc(amount) which only changed the
+ * symbol (e.g. "$10" → "£10") without converting the numeric value. The fix
+ * wraps every amount with convertCurrency(amount, "USD", currencyCode) first,
+ * matching the dashboard pattern.
+ */
+
+import { describe, it, expect } from "vitest";
+import { convertCurrency, formatCurrency } from "@/lib/currency";
+
+describe("BUG-DAILY-1: subscription amount currency conversion", () => {
+  it("convertCurrency changes the numeric value when converting USD to GBP", () => {
+    const usdAmount = 10;
+    const converted = convertCurrency(usdAmount, "USD", "GBP");
+    // GBP rate is 1.27 (USD per GBP), so $10 ≈ £7.87
+    // The converted value must NOT equal the original amount
+    expect(converted).not.toBe(usdAmount);
+    // Converted value should be less than 10 (GBP is worth more than USD)
+    expect(converted).toBeLessThan(usdAmount);
+    // Should be roughly in range of ~7–9 GBP
+    expect(converted).toBeGreaterThan(6);
+    expect(converted).toBeLessThan(9);
+  });
+
+  it("formatCurrency without conversion produces wrong symbol-only substitution for GBP", () => {
+    const usdAmount = 10;
+    // Bug: just formatting $10 as GBP gives "£10.00" — wrong amount
+    const wrongDisplay = formatCurrency(usdAmount, "GBP");
+    // Fix: convert first, then format
+    const correctDisplay = formatCurrency(convertCurrency(usdAmount, "USD", "GBP"), "GBP");
+    // The two results must differ — proving the bug when conversion is skipped
+    expect(wrongDisplay).not.toBe(correctDisplay);
+    // Wrong path: symbol changed but value is still 10
+    expect(wrongDisplay).toBe("£10.00");
+    // Correct path: value is converted (~7.87), not 10
+    expect(correctDisplay).not.toBe("£10.00");
+  });
+
+  it("converting USD to USD is a no-op (same-currency guard)", () => {
+    const amount = 42.5;
+    expect(convertCurrency(amount, "USD", "USD")).toBe(amount);
+  });
+
+  it("converts USD to EUR correctly", () => {
+    // EUR rate: 1 EUR = 1.08 USD, so $10 ≈ €9.26
+    const converted = convertCurrency(10, "USD", "EUR");
+    expect(converted).toBeGreaterThan(8);
+    expect(converted).toBeLessThan(11);
+    // Must differ from original
+    expect(converted).not.toBe(10);
+  });
+
+  it("totalMonthly correctly reflects converted value for GBP display", () => {
+    // Simulates the page: totalMonthly comes from the API in USD
+    const totalMonthlyUSD = 50;
+    const converted = convertCurrency(totalMonthlyUSD, "USD", "GBP");
+    // The displayed amount must be the converted value, not the raw API value
+    expect(converted).not.toBe(totalMonthlyUSD);
+    const displayedText = formatCurrency(converted, "GBP");
+    // Must NOT be "£50.00" — that was the bug
+    expect(displayedText).not.toBe("£50.00");
+    // Must be a GBP-formatted amount less than 50
+    expect(displayedText).toMatch(/^£/);
+    expect(converted).toBeLessThan(50);
+  });
+});

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, HelpCircle } from "lucide-react";
 import { motion } from "motion/react";
 import { useSubscriptions } from "@/hooks/useSubscriptions";
 import { useCurrency } from "@/hooks/useCurrency";
+import { convertCurrency } from "@/lib/currency";
 
 function MerchantAvatar({ name, color }: { name: string; color: string }) {
   return (
@@ -18,7 +19,7 @@ function MerchantAvatar({ name, color }: { name: string; color: string }) {
 
 export default function SubscriptionsPage() {
   const { subscriptions, totalMonthly, totalAnnual, loading, detecting, error, detect, dismiss, dismissPriceChange } = useSubscriptions();
-  const { format: fc, formatAbs: fca } = useCurrency();
+  const { format: fc, formatAbs: fca, currencyCode } = useCurrency();
 
   if (loading) {
     return (
@@ -47,7 +48,7 @@ export default function SubscriptionsPage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Subscriptions</h1>
         <p className="text-sm text-gray-500 mt-1">
-          {subscriptions.length} active · {fc(totalMonthly)}/mo · {fc(totalAnnual)}/yr
+          {subscriptions.length} active · {fc(convertCurrency(totalMonthly, "USD", currencyCode))}/mo · {fc(convertCurrency(totalAnnual, "USD", currencyCode))}/yr
         </p>
       </div>
       <button
@@ -71,11 +72,11 @@ export default function SubscriptionsPage() {
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Monthly</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalMonthly)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalMonthly, "USD", currencyCode))}</div>
             </div>
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Annual</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalAnnual)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalAnnual, "USD", currencyCode))}</div>
             </div>
           </div>
           <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
@@ -108,7 +109,7 @@ export default function SubscriptionsPage() {
                         }`}
                         title="Click to dismiss"
                       >
-                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(sub.priceChange.change)}
+                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(convertCurrency(sub.priceChange.change, "USD", currencyCode))}
                       </button>
                     )}
                   </div>
@@ -118,7 +119,7 @@ export default function SubscriptionsPage() {
                 </div>
                 <div className="text-right shrink-0">
                   <div className="text-sm font-bold text-gray-900">
-                    {fca(sub.amount)}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
+                    {fca(convertCurrency(sub.amount, "USD", currencyCode))}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
                   </div>
                 </div>
                 <button
@@ -159,7 +160,7 @@ export default function SubscriptionsPage() {
                     <div key={sub.id}>
                       <div className="flex items-center justify-between text-xs mb-1">
                         <span className="text-gray-600">{sub.merchant}</span>
-                        <span className="text-gray-500">{fc(yearly)}/yr</span>
+                        <span className="text-gray-500">{fc(convertCurrency(yearly, "USD", currencyCode))}/yr</span>
                       </div>
                       <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
                         <motion.div


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 3
**Bugs verified (survived Devil's Advocate)**: 2
**Bugs fixed (with tests)**: 2
**Bugs deferred**: 0
**False positives rejected**: 1

## Fixed Bugs

### P0 — Critical
- **BUG-CRITICAL-1**: Missing session ownership check in `migrate-token` — `app/api/cards/migrate-token/route.ts` (test: `app/api/cards/__tests__/migrate-token.test.ts`)
  
  The `card_session_id` cookie has a 30-day maxAge. Sessions created by authenticated Coconut users had `clerk_user_id` set, but `migrate-token` never validated it against the current user — another user on the same device could claim the session and gain access to the original user's Plaid bank connection. Fixed by adding `clerk_user_id` to the select and returning 403 when it doesn't match the current user.

### P2 — Incorrect Behavior
- **BUG-DAILY-1**: Subscription amounts displayed without currency conversion — `app/app/subscriptions/page.tsx` (test: `app/app/subscriptions/__tests__/page.test.ts`)
  
  The subscriptions page formatted amounts with `fc(amount)` (attaches currency symbol only) without calling `convertCurrency()` first. A user with display currency GBP would see a $10 subscription as "£10" instead of "~£8". Dashboard already applied `convertCurrency(amount, "USD", currencyCode)` correctly — subscriptions page now does the same.

## Tests Added
- `app/api/cards/__tests__/migrate-token.test.ts` — 4 tests: ownership mismatch → 403, NULL clerk_user_id claimable, owner can migrate own session, fully valid session blocked when user mismatch
- `app/app/subscriptions/__tests__/page.test.ts` — 5 tests: USD→GBP conversion changes value, same-currency no-op, USD→EUR range, formatCurrency without conversion documents wrong behavior

## Disproved Bugs (Rejected by Devil's Advocate)
- **BUG-RESILIENCE-1**: `resp.json()` before `!resp.ok` check in `app/cards/page.tsx` — All 4 call sites are inside try-catch blocks that properly catch SyntaxError and show the user a generic error message. Feature doesn't crash. Code quality issue, not a functional bug.

## Patterns Found
- BUG-DAILY-1 matches existing rule #3 in `.cursor/rules/common-bugs.mdc` ("apply `convertCurrency()` before `formatCurrency()`"). No new rules added — pattern threshold (3+ occurrences) not met for BUG-CRITICAL-1.

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (0 errors, 70 warnings — same as baseline)
- [x] `npm run test` — passes (63 files, 631 tests, +9 new tests added, all green)

---
Generated by Bug Council v2 (evidence-based)