### PR TITLE
fix: bug council audit — 1 bug fixed

### DIFF
--- a/app/app/subscriptions/__tests__/page.test.ts
+++ b/app/app/subscriptions/__tests__/page.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { convertCurrency, formatCurrency } from "@/lib/currency";
+
+describe("BUG-CLIENT-1: subscription amounts require currency conversion", () => {
+  it("formatCurrency alone does not convert USD amounts to display currency", () => {
+    // Without convertCurrency (the bug), a $15.99 amount formatted as EUR shows the wrong number.
+    // The EUR locale (de-DE) uses comma as decimal separator, so 15.99 appears as "15,99 €".
+    const usdAmount = 15.99;
+    const withoutConversion = formatCurrency(usdAmount, "EUR");
+    const withConversion = formatCurrency(convertCurrency(usdAmount, "USD", "EUR"), "EUR");
+    // Bug: both are "formatted" but only withConversion has the correct exchange rate applied
+    expect(withoutConversion).not.toBe(withConversion);
+    // withoutConversion encodes the raw USD numeric value (15.99 → "15,99" in de-DE locale) — the bug
+    expect(withoutConversion).toContain("15,99");
+    // withConversion has a different numeric value after conversion (USD→EUR rate ~0.926)
+    expect(withConversion).not.toContain("15,99");
+  });
+
+  it("convertCurrency(x, 'USD', 'USD') is a no-op — USD users unaffected", () => {
+    const amount = 15.99;
+    expect(convertCurrency(amount, "USD", "USD")).toBe(amount);
+  });
+
+  it("totalMonthly displayed for non-USD user needs conversion", () => {
+    const totalMonthlyUSD = 26.98;
+    // Broken: fc(totalMonthly) → displays "$26.98" value as "€26.98"
+    const broken = formatCurrency(totalMonthlyUSD, "EUR");
+    // Fixed: fc(convertCurrency(totalMonthly, "USD", currencyCode))
+    const fixed = formatCurrency(convertCurrency(totalMonthlyUSD, "USD", "EUR"), "EUR");
+    expect(broken).not.toBe(fixed);
+    // The fixed value is smaller (EUR is stronger than USD at current rates)
+    expect(convertCurrency(totalMonthlyUSD, "USD", "EUR")).toBeLessThan(totalMonthlyUSD);
+  });
+});

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, HelpCircle } from "lucide-react";
 import { motion } from "motion/react";
 import { useSubscriptions } from "@/hooks/useSubscriptions";
 import { useCurrency } from "@/hooks/useCurrency";
+import { convertCurrency } from "@/lib/currency";
 
 function MerchantAvatar({ name, color }: { name: string; color: string }) {
   return (
@@ -18,7 +19,7 @@ function MerchantAvatar({ name, color }: { name: string; color: string }) {
 
 export default function SubscriptionsPage() {
   const { subscriptions, totalMonthly, totalAnnual, loading, detecting, error, detect, dismiss, dismissPriceChange } = useSubscriptions();
-  const { format: fc, formatAbs: fca } = useCurrency();
+  const { format: fc, formatAbs: fca, currencyCode } = useCurrency();
 
   if (loading) {
     return (
@@ -47,7 +48,7 @@ export default function SubscriptionsPage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Subscriptions</h1>
         <p className="text-sm text-gray-500 mt-1">
-          {subscriptions.length} active · {fc(totalMonthly)}/mo · {fc(totalAnnual)}/yr
+          {subscriptions.length} active · {fc(convertCurrency(totalMonthly, "USD", currencyCode))}/mo · {fc(convertCurrency(totalAnnual, "USD", currencyCode))}/yr
         </p>
       </div>
       <button
@@ -71,11 +72,11 @@ export default function SubscriptionsPage() {
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Monthly</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalMonthly)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalMonthly, "USD", currencyCode))}</div>
             </div>
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Annual</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalAnnual)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalAnnual, "USD", currencyCode))}</div>
             </div>
           </div>
           <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
@@ -108,7 +109,7 @@ export default function SubscriptionsPage() {
                         }`}
                         title="Click to dismiss"
                       >
-                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(sub.priceChange.change)}
+                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(convertCurrency(sub.priceChange.change, "USD", currencyCode))}
                       </button>
                     )}
                   </div>
@@ -118,7 +119,7 @@ export default function SubscriptionsPage() {
                 </div>
                 <div className="text-right shrink-0">
                   <div className="text-sm font-bold text-gray-900">
-                    {fca(sub.amount)}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
+                    {fca(convertCurrency(sub.amount, "USD", currencyCode))}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
                   </div>
                 </div>
                 <button
@@ -159,7 +160,7 @@ export default function SubscriptionsPage() {
                     <div key={sub.id}>
                       <div className="flex items-center justify-between text-xs mb-1">
                         <span className="text-gray-600">{sub.merchant}</span>
-                        <span className="text-gray-500">{fc(yearly)}/yr</span>
+                        <span className="text-gray-500">{fc(convertCurrency(yearly, "USD", currencyCode))}/yr</span>
                       </div>
                       <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
                         <motion.div


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 2
**Bugs verified (survived Devil's Advocate)**: 1
**Bugs fixed (with tests)**: 1
**Bugs deferred**: 0
**False positives rejected**: 1

## Fixed Bugs

### P0 — Critical
None

### P1 — Broken Functionality
None

### P2 — Incorrect Behavior
- **BUG-CLIENT-1**: Subscription amounts not converted to display currency — `app/app/subscriptions/page.tsx` (test: `app/app/subscriptions/__tests__/page.test.ts`)

  All `convertCurrency(amount, "USD", currencyCode)` calls were removed from the subscriptions page. The `fc()` function from `useCurrency` only applies `Intl.NumberFormat` formatting without converting numeric values. Subscription amounts are stored in USD (from Plaid). Non-USD users (EUR, GBP, JPY, etc.) saw raw USD numbers with the wrong currency symbol — e.g., "€15.99" instead of "€14.81" for a Netflix subscription.

  Fix: restored `convertCurrency` import, `currencyCode` from `useCurrency`, and wrapped all 6 monetary display sites.

## Tests Added
- `app/app/subscriptions/__tests__/page.test.ts` — 3 tests covering: (1) `formatCurrency` alone retains raw USD value for non-USD currencies, (2) `convertCurrency(x, 'USD', 'USD')` is a no-op so USD users are unaffected, (3) non-USD totalMonthly display requires conversion

## Deferred Bugs (Not Fixed)
None

## Disproved Bugs (Rejected by Devil's Advocate)
- **BUG-CRITICAL-1**: migrate-token route missing ownership check — Structurally impossible attack. Sessions with a `plaid_access_token` are created by `analyze-plaid` (guest flow, always `clerk_user_id = NULL`). Sessions created by `analyze-coconut` (authenticated users, has `clerk_user_id`) never store a `plaid_access_token`. These two flows are mutually exclusive — no DB row can ever have both fields set simultaneously, making the ownership check dead code guarding an unreachable state.

## Patterns Found
- Recurring pattern: `convertCurrency` removal causing wrong values for non-USD users. This has now appeared in PR #263 (sign convention), PR #264 (dashboard), and now PR #269 (subscriptions). **Pattern already in `.cursor/rules/common-bugs.mdc`**: "Apply `convertCurrency()` before `formatCurrency()`."

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (70 warnings same as baseline, 0 errors)
- [x] `npm run test` — passes (62 files, 625 tests — 3 new tests added, all green)

---
Generated by Bug Council v2 (evidence-based)