### PR TITLE
fix: bug council audit — 1 bug fixed

### DIFF
--- a/app/app/subscriptions/__tests__/page.test.ts
+++ b/app/app/subscriptions/__tests__/page.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for BUG-SUBS-1: Subscriptions page displays wrong numeric values for non-USD users.
+ *
+ * Subscription amounts are stored in USD. `useCurrency().format` (fc) only formats
+ * with the user's locale and symbol — it does NOT convert currencies. Without
+ * `convertCurrency(amount, "USD", currencyCode)`, a EUR user with a $15.99/month
+ * subscription sees "€15,99" (wrong USD value, wrong symbol) instead of the
+ * correct "€14,81".
+ *
+ * The React component itself cannot be unit-tested in isolation because it requires
+ * Clerk auth context, custom hooks, and Next.js infrastructure. However, the buggy
+ * pattern is entirely in the pure utility layer:
+ *   - `formatCurrency(amount, "EUR")` formats a USD amount with the EUR symbol
+ *     without converting — this is the bug.
+ *   - `formatCurrency(convertCurrency(amount, "USD", "EUR"), "EUR")` first converts
+ *     to EUR, then formats — this is the fix.
+ *
+ * These tests verify:
+ *   1. formatCurrency alone does NOT convert (it only labels the amount).
+ *   2. convertCurrency produces a different (correct) value for non-USD amounts.
+ *   3. The combined pattern (convert then format) produces the correct display string.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatCurrency, formatCurrencyAbs, convertCurrency } from "@/lib/currency";
+
+describe("BUG-SUBS-1: subscription amount display for non-USD users", () => {
+  const USD_AMOUNT = 15.99; // stored subscription price in USD
+
+  it("formatCurrency alone does not convert — bug: EUR user sees USD value with EUR symbol", () => {
+    // Without convertCurrency, the raw USD amount is formatted with the EUR symbol.
+    // This is exactly what the old code did: fc(sub.amount) where fc = useCurrency().format
+    // bound to "EUR". The numeric value is unchanged — only the symbol is wrong.
+    const buggyOutput = formatCurrency(USD_AMOUNT, "EUR");
+
+    // The numeric value is still the USD amount (15.99), just labeled as EUR.
+    // A correct EUR conversion of $15.99 at 1 USD = ~0.926 EUR would be ≈14.81 EUR,
+    // which is a different number. The buggy output must NOT equal a correct conversion.
+    const correctEurAmount = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    expect(correctEurAmount).not.toBeCloseTo(USD_AMOUNT, 1); // conversion changes the value
+    expect(buggyOutput).not.toEqual(formatCurrency(correctEurAmount, "EUR"));
+  });
+
+  it("convertCurrency(amount, 'USD', 'EUR') produces a smaller value than the USD amount", () => {
+    // 1 USD < 1 EUR in purchasing power, so a USD amount converts to a smaller EUR number.
+    // EUR rate to USD = 1.08 (per lib/currency.ts), so $15.99 USD = 15.99 / 1.08 ≈ 14.81 EUR.
+    const eurAmount = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    expect(eurAmount).toBeCloseTo(14.81, 1);
+    expect(eurAmount).toBeLessThan(USD_AMOUNT);
+  });
+
+  it("correct pattern: convertCurrency then format produces the right display string for EUR", () => {
+    // This is what the fixed code does at all 6 display sites:
+    //   fc(convertCurrency(amount, "USD", currencyCode))
+    const eurAmount = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    const displayed = formatCurrency(eurAmount, "EUR");
+
+    // Should contain the euro sign and reflect the converted (smaller) number.
+    expect(displayed).toContain("€");
+    // The EUR-formatted string should NOT contain "15,99" or "15.99" — the raw USD amount.
+    expect(displayed).not.toMatch(/15[,.]99/);
+    // It should contain approximately 14.81 (the converted value).
+    expect(displayed).toMatch(/14[,.]8/);
+  });
+
+  it("formatCurrencyAbs conversion is also correct for price-change badge (sub.priceChange.change)", () => {
+    // fca(convertCurrency(sub.priceChange.change, "USD", currencyCode)) — fixed pattern
+    const priceChange = 2.0; // $2 USD price increase
+    const converted = convertCurrency(priceChange, "USD", "EUR");
+    const displayed = formatCurrencyAbs(converted, "EUR");
+
+    // Should be less than $2 when converted to EUR
+    expect(converted).toBeLessThan(priceChange);
+    expect(displayed).toContain("€");
+  });
+});

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, HelpCircle } from "lucide-react";
 import { motion } from "motion/react";
 import { useSubscriptions } from "@/hooks/useSubscriptions";
 import { useCurrency } from "@/hooks/useCurrency";
+import { convertCurrency } from "@/lib/currency";
 
 function MerchantAvatar({ name, color }: { name: string; color: string }) {
   return (
@@ -18,7 +19,7 @@ function MerchantAvatar({ name, color }: { name: string; color: string }) {
 
 export default function SubscriptionsPage() {
   const { subscriptions, totalMonthly, totalAnnual, loading, detecting, error, detect, dismiss, dismissPriceChange } = useSubscriptions();
-  const { format: fc, formatAbs: fca } = useCurrency();
+  const { format: fc, formatAbs: fca, currencyCode } = useCurrency();
 
   if (loading) {
     return (
@@ -47,7 +48,7 @@ export default function SubscriptionsPage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Subscriptions</h1>
         <p className="text-sm text-gray-500 mt-1">
-          {subscriptions.length} active · {fc(totalMonthly)}/mo · {fc(totalAnnual)}/yr
+          {subscriptions.length} active · {fc(convertCurrency(totalMonthly, "USD", currencyCode))}/mo · {fc(convertCurrency(totalAnnual, "USD", currencyCode))}/yr
         </p>
       </div>
       <button
@@ -71,11 +72,11 @@ export default function SubscriptionsPage() {
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Monthly</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalMonthly)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalMonthly, "USD", currencyCode))}</div>
             </div>
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Annual</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalAnnual)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalAnnual, "USD", currencyCode))}</div>
             </div>
           </div>
           <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
@@ -108,7 +109,7 @@ export default function SubscriptionsPage() {
                         }`}
                         title="Click to dismiss"
                       >
-                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(sub.priceChange.change)}
+                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(convertCurrency(sub.priceChange.change, "USD", currencyCode))}
                       </button>
                     )}
                   </div>
@@ -118,7 +119,7 @@ export default function SubscriptionsPage() {
                 </div>
                 <div className="text-right shrink-0">
                   <div className="text-sm font-bold text-gray-900">
-                    {fca(sub.amount)}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
+                    {fca(convertCurrency(sub.amount, "USD", currencyCode))}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
                   </div>
                 </div>
                 <button
@@ -159,7 +160,7 @@ export default function SubscriptionsPage() {
                     <div key={sub.id}>
                       <div className="flex items-center justify-between text-xs mb-1">
                         <span className="text-gray-600">{sub.merchant}</span>
-                        <span className="text-gray-500">{fc(yearly)}/yr</span>
+                        <span className="text-gray-500">{fc(convertCurrency(yearly, "USD", currencyCode))}/yr</span>
                       </div>
                       <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
                         <motion.div


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 4 (all the same bug, reported across 4 domains)
**Bugs verified (survived Devil's Advocate)**: 1
**Bugs fixed (with tests)**: 1
**Bugs deferred**: 0
**False positives rejected**: 0

## Fixed Bugs

### P0 — Critical
None

### P1 — Broken Functionality
None

### P2 — Incorrect Behavior
- **BUG-SUBS-1**: Subscriptions page missing currency conversion for non-USD users — `app/app/subscriptions/page.tsx` (test: `app/app/subscriptions/__tests__/page.test.ts`)

## Tests Added
- `app/app/subscriptions/__tests__/page.test.ts` — 4 tests covering that `formatCurrency` alone does not convert, `convertCurrency("USD"→"EUR")` produces a different value, and the combined pattern produces correct display output for both amount and price-change badge sites

## Deferred Bugs (Not Fixed)
None

## Disproved Bugs (Rejected by Devil's Advocate)
None — the one reported bug was unanimously verified

## Patterns Found
This is a regression of Pattern #3 (`Apply convertCurrency() before formatCurrency()`), which is already documented in `.cursor/rules/common-bugs.mdc`. The recent commit `cfbcd98` removed the `convertCurrency` import and all 6 call sites from `subscriptions/page.tsx`, breaking currency display for non-USD users. No new patterns added.

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (no new errors vs baseline)
- [x] `npm run test` — passes (4 new tests added, 62 files pass vs 61 baseline)

---
Generated by Bug Council v2 (evidence-based)