### PR TITLE
fix: bug council audit — 2 bugs fixed

### DIFF
--- a/app/app/subscriptions/__tests__/page.test.ts
+++ b/app/app/subscriptions/__tests__/page.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for BUG-CLIENT-1: Subscriptions page displays USD amounts without currency conversion
+ *
+ * The React component itself cannot be unit-tested in isolation because it
+ * requires Clerk auth context, custom hooks, and Next.js infrastructure.
+ *
+ * Instead, these tests validate the pure utility layer used by the fix:
+ *   - formatCurrency alone does NOT convert currencies (it only formats)
+ *   - convertCurrency produces the correct target-currency numeric value
+ *   - the combined pattern (convertCurrency → formatCurrency) produces the
+ *     correct display string for a non-USD user
+ *
+ * Bug-ID: BUG-CLIENT-1
+ * Severity: P2
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatCurrency, formatCurrencyAbs, convertCurrency } from "@/lib/currency";
+
+// EUR rate: 1 EUR = 1.08 USD, so 1 USD = 1/1.08 EUR ≈ 0.9259 EUR
+// $15.99 USD → 15.99 / 1.08 ≈ 14.8056 EUR
+const USD_AMOUNT = 15.99;
+const EUR_RATE_TO_USD = 1.08;
+const EXPECTED_EUR = USD_AMOUNT / EUR_RATE_TO_USD; // ≈ 14.81
+
+describe("BUG-CLIENT-1: subscriptions page currency conversion", () => {
+  it("formatCurrency alone does NOT convert — it formats the raw number with a different symbol", () => {
+    // Before the fix, the page called fc(amount) without convertCurrency.
+    // For a EUR user, fc() calls formatCurrency(amount, "EUR") which formats
+    // the USD numeric value with the EUR symbol — no conversion.
+    const buggyOutput = formatCurrency(USD_AMOUNT, "EUR");
+    // The buggy output shows the USD numeric value (15.99) with EUR symbol.
+    // It must NOT equal the correctly converted EUR display.
+    const correctOutput = formatCurrency(EXPECTED_EUR, "EUR");
+    expect(buggyOutput).not.toBe(correctOutput);
+  });
+
+  it("convertCurrency converts USD to EUR correctly", () => {
+    const result = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    // 15.99 / 1.08 ≈ 14.8056
+    expect(result).toBeCloseTo(EXPECTED_EUR, 2);
+  });
+
+  it("convertCurrency is a no-op when source and target are the same", () => {
+    const result = convertCurrency(USD_AMOUNT, "USD", "USD");
+    expect(result).toBe(USD_AMOUNT);
+  });
+
+  it("combined pattern (convertCurrency then formatCurrency) produces correct EUR display string", () => {
+    const converted = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    const displayed = formatCurrency(converted, "EUR");
+    // The correctly converted and formatted EUR amount should NOT contain $15.99
+    expect(displayed).not.toContain("15,99");
+    // It should represent the converted value (~14.81)
+    expect(displayed).toContain("14,8");
+  });
+
+  it("formatCurrencyAbs without conversion shows wrong value for non-USD users", () => {
+    // Before fix: fca(sub.amount) with EUR user shows $15.99 formatted as EUR
+    const buggyOutput = formatCurrencyAbs(USD_AMOUNT, "EUR");
+    const correctOutput = formatCurrencyAbs(convertCurrency(USD_AMOUNT, "USD", "EUR"), "EUR");
+    expect(buggyOutput).not.toBe(correctOutput);
+  });
+
+  it("combined pattern with formatCurrencyAbs produces correct EUR absolute display", () => {
+    const converted = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    const displayed = formatCurrencyAbs(converted, "EUR");
+    expect(displayed).toContain("14,8");
+  });
+});

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, HelpCircle } from "lucide-react";
 import { motion } from "motion/react";
 import { useSubscriptions } from "@/hooks/useSubscriptions";
 import { useCurrency } from "@/hooks/useCurrency";
+import { convertCurrency } from "@/lib/currency";
 
 function MerchantAvatar({ name, color }: { name: string; color: string }) {
   return (
@@ -18,7 +19,7 @@ function MerchantAvatar({ name, color }: { name: string; color: string }) {
 
 export default function SubscriptionsPage() {
   const { subscriptions, totalMonthly, totalAnnual, loading, detecting, error, detect, dismiss, dismissPriceChange } = useSubscriptions();
-  const { format: fc, formatAbs: fca } = useCurrency();
+  const { format: fc, formatAbs: fca, currencyCode } = useCurrency();
 
   if (loading) {
     return (
@@ -47,7 +48,7 @@ export default function SubscriptionsPage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Subscriptions</h1>
         <p className="text-sm text-gray-500 mt-1">
-          {subscriptions.length} active · {fc(totalMonthly)}/mo · {fc(totalAnnual)}/yr
+          {subscriptions.length} active · {fc(convertCurrency(totalMonthly, "USD", currencyCode))}/mo · {fc(convertCurrency(totalAnnual, "USD", currencyCode))}/yr
         </p>
       </div>
       <button
@@ -71,11 +72,11 @@ export default function SubscriptionsPage() {
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Monthly</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalMonthly)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalMonthly, "USD", currencyCode))}</div>
             </div>
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Annual</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalAnnual)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalAnnual, "USD", currencyCode))}</div>
             </div>
           </div>
           <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
@@ -108,7 +109,7 @@ export default function SubscriptionsPage() {
                         }`}
                         title="Click to dismiss"
                       >
-                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(sub.priceChange.change)}
+                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(convertCurrency(sub.priceChange.change, "USD", currencyCode))}
                       </button>
                     )}
                   </div>
@@ -118,7 +119,7 @@ export default function SubscriptionsPage() {
                 </div>
                 <div className="text-right shrink-0">
                   <div className="text-sm font-bold text-gray-900">
-                    {fca(sub.amount)}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
+                    {fca(convertCurrency(sub.amount, "USD", currencyCode))}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
                   </div>
                 </div>
                 <button
@@ -159,7 +160,7 @@ export default function SubscriptionsPage() {
                     <div key={sub.id}>
                       <div className="flex items-center justify-between text-xs mb-1">
                         <span className="text-gray-600">{sub.merchant}</span>
-                        <span className="text-gray-500">{fc(yearly)}/yr</span>
+                        <span className="text-gray-500">{fc(convertCurrency(yearly, "USD", currencyCode))}/yr</span>
                       </div>
                       <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
                         <motion.div

--- a/lib/__tests__/subscription-detect.test.ts
+++ b/lib/__tests__/subscription-detect.test.ts
@@ -54,7 +54,7 @@ vi.mock("../supabase", () => ({
   }),
 }));
 
-import { saveDetectedSubscriptions } from "../subscription-detect";
+import { saveDetectedSubscriptions, deleteExcludedSubscriptions } from "../subscription-detect";
 import type { DetectedSubscription } from "../subscription-detect";
 
 function makeDetected(overrides?: Partial<DetectedSubscription>): DetectedSubscription {
@@ -181,5 +181,28 @@ describe("saveDetectedSubscriptions — error propagation (BUG-RESILIENCE-1)", (
       expect(mockUpdateResult).not.toHaveBeenCalled();
       expect(mockUpsertResult).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("deleteExcludedSubscriptions — SELECT error propagation (BUG-RESILIENCE-1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when the Supabase SELECT returns an error instead of silently returning 0", async () => {
+    mockSelectResult.mockResolvedValue({
+      data: null,
+      error: { message: "connection timeout" },
+    });
+
+    await expect(deleteExcludedSubscriptions("user-1")).rejects.toThrow(
+      "Failed to load subscriptions: connection timeout"
+    );
+  });
+
+  it("returns 0 when SELECT returns empty rows (no error)", async () => {
+    mockSelectResult.mockResolvedValue({ data: [], error: null });
+
+    await expect(deleteExcludedSubscriptions("user-1")).resolves.toBe(0);
   });
 });

--- a/lib/subscription-detect.ts
+++ b/lib/subscription-detect.ts
@@ -13,11 +13,12 @@ import { matchKnownSubscription } from "./known-subscriptions";
 
 export async function deleteExcludedSubscriptions(clerkUserId: string): Promise<number> {
   const db = getSupabase();
-  const { data: rows } = await db
+  const { data: rows, error } = await db
     .from("subscriptions")
     .select("id, merchant_name, primary_category")
     .eq("clerk_user_id", clerkUserId)
     .eq("status", "active");
+  if (error) throw new Error(`Failed to load subscriptions: ${error.message}`);
   if (!rows?.length) return 0;
   const toDelete = rows.filter((r) =>
     shouldExcludeAsSubscription(r.primary_category, r.merchant_name ?? "", "")


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 6 (4 were duplicates of the same subscriptions regression)
**Bugs verified (survived Devil's Advocate)**: 2
**Bugs fixed (with tests)**: 2
**Bugs deferred**: 0
**False positives rejected**: 0

## Fixed Bugs

### P0 — Critical
None

### P1 — Broken Functionality
**BUG-RESILIENCE-1**: Missing error destructuring in `deleteExcludedSubscriptions` SELECT — `lib/subscription-detect.ts` (test: `lib/__tests__/subscription-detect.test.ts`)

The function only destructured `data` from a Supabase SELECT, silently dropping `error`. On query failure, `rows` becomes `null`, the function returns 0 (success), and previously-excluded subscriptions could be re-inserted by a subsequent detection run. Fix: destructure `{ data: rows, error }` and throw on error so the API route's try-catch surfaces it.

### P2 — Incorrect Behavior
**BUG-CLIENT-1**: Subscriptions page displays raw USD amounts with user's currency symbol — `app/app/subscriptions/page.tsx` (test: `app/app/subscriptions/__tests__/page.test.ts`)

The `convertCurrency` import and all 6 `convertCurrency()` call sites were stripped in commit `90411a7`. Subscription amounts are stored in USD; `useCurrency().format()` only applies locale/symbol formatting — it does NOT convert. A EUR user with a $15.99/month subscription saw "€15,99" instead of the correct "€14,81". Fix: restore the import, destructure `currencyCode`, and wrap all display sites with `convertCurrency(amount, "USD", currencyCode)`.

## Tests Added
- `app/app/subscriptions/__tests__/page.test.ts` — 6 tests validating the currency conversion pattern (re-created after deletion)
- `lib/__tests__/subscription-detect.test.ts` — 2 new tests: throws on SELECT error, returns 0 on empty rows

## Deferred Bugs (Not Fixed)
None

## Disproved Bugs (Rejected by Devil's Advocate)
None — both reported bugs were confirmed real

## Patterns Found
- **Subscriptions currency regression**: This is the third time `convertCurrency` calls have been stripped from subscription display (previously BUG-SUBS-1 in PR #271). High regression risk — the compiler cannot catch this since `useCurrency().format()` accepts a number and silently produces wrong output for non-USD users.

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (70 warnings, 0 errors — same as baseline)
- [x] `npm run test` — passes (630 tests, +8 new tests, all green)

---
Generated by Bug Council v2 (evidence-based)