### PR TITLE
fix: bug council audit — 3 bugs fixed

### DIFF
--- a/app/api/stripe/terminal/__tests__/create-payment-intent.test.ts
+++ b/app/api/stripe/terminal/__tests__/create-payment-intent.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * Tests for POST /api/stripe/terminal/create-payment-intent
+ *
+ * BUG-CRITICAL-1: Connected Account lookup ran whenever receiverMemberId was
+ * present, even when groupId was absent. This meant an attacker could set
+ * transfer_data.destination to any platform member's Stripe Connected Account
+ * without passing the canAccessGroup auth check.
+ *
+ * Fix: the Connected Account lookup block now requires
+ *   body.receiverMemberId && body.groupId && body.payerMemberId
+ * so it only runs after the full group auth check has been validated.
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/group-access", () => ({
+  canAccessGroup: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabase: vi.fn(),
+}));
+
+// Stripe mock: use a class so `new Stripe(key)` works.
+// The instance methods are spies stored in module-level variables so tests can inspect them.
+const mockPaymentIntentsCreate = vi.fn();
+const mockAccountsRetrieve = vi.fn();
+
+vi.mock("stripe", () => {
+  class MockStripe {
+    paymentIntents = { create: mockPaymentIntentsCreate };
+    accounts = { retrieve: mockAccountsRetrieve };
+    static errors = {
+      StripeError: class StripeError extends Error {},
+    };
+  }
+  return { default: MockStripe };
+});
+
+import { auth } from "@clerk/nextjs/server";
+import { canAccessGroup } from "@/lib/group-access";
+import { getSupabase } from "@/lib/supabase";
+
+const mockAuth = vi.mocked(auth);
+const mockCanAccessGroup = vi.mocked(canAccessGroup);
+const mockGetSupabase = vi.mocked(getSupabase);
+
+import { POST } from "../create-payment-intent/route";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/stripe/terminal/create-payment-intent", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Build a minimal Supabase db mock.
+ * receiverUserId: the user_id that group_members returns for receiverMemberId lookups.
+ * stripeAccountId: the stripe_account_id that stripe_connected_accounts returns.
+ * groupMembersInGroup: rows returned for the "are payer+receiver in the group?" check.
+ */
+function makeDb(opts: {
+  receiverUserId?: string | null;
+  stripeAccountId?: string | null;
+  groupMembersInGroup?: Array<{ id: string }>;
+}) {
+  const { receiverUserId = null, stripeAccountId = null, groupMembersInGroup = [] } = opts;
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "group_members") {
+        // Two different queries hit this table:
+        // 1. .select("id").eq("group_id", ...).in("id", [...]) — group membership check
+        // 2. .select("user_id").eq("id", receiverMemberId).maybeSingle() — receiver lookup
+        const chain: Record<string, unknown> = {};
+        chain.select = vi.fn(() => chain);
+        chain.eq = vi.fn(() => chain);
+        chain.in = vi.fn(() => Promise.resolve({ data: groupMembersInGroup, error: null }));
+        chain.maybeSingle = vi
+          .fn()
+          .mockResolvedValue({
+            data: receiverUserId ? { user_id: receiverUserId } : null,
+            error: null,
+          });
+        return chain;
+      }
+
+      if (table === "stripe_connected_accounts") {
+        const chain: Record<string, unknown> = {};
+        chain.select = vi.fn(() => chain);
+        chain.eq = vi.fn(() => chain);
+        chain.maybeSingle = vi.fn().mockResolvedValue({
+          data: stripeAccountId ? { stripe_account_id: stripeAccountId } : null,
+          error: null,
+        });
+        return chain;
+      }
+
+      // Fallback
+      const chain: Record<string, unknown> = {};
+      chain.select = vi.fn(() => chain);
+      chain.eq = vi.fn(() => chain);
+      chain.maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+      return chain;
+    }),
+  };
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.STRIPE_SECRET_KEY = "sk_test_placeholder";
+
+  mockAuth.mockResolvedValue({ userId: "clerk_user_test" } as Awaited<
+    ReturnType<typeof auth>
+  >);
+
+  mockCanAccessGroup.mockResolvedValue(true);
+
+  // Default: Stripe accounts.retrieve returns a US account
+  mockAccountsRetrieve.mockResolvedValue({ country: "US" });
+
+  // Default: PaymentIntent create succeeds
+  mockPaymentIntentsCreate.mockResolvedValue({
+    client_secret: "pi_test_secret",
+    id: "pi_test_id",
+  });
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_SECRET_KEY;
+  vi.clearAllMocks();
+});
+
+// ── BUG-CRITICAL-1 tests ─────────────────────────────────────────────────────
+
+describe("BUG-CRITICAL-1: Connected Account lookup requires groupId + payerMemberId", () => {
+  it("does NOT set transfer_data when receiverMemberId is present but groupId is omitted", async () => {
+    /**
+     * This test FAILS against the old code because the old code runs the
+     * Connected Account lookup block whenever body.receiverMemberId is truthy,
+     * regardless of groupId. With a valid stripeAccountId returned from the DB,
+     * transfer_data.destination would be set.
+     *
+     * With the fix, the lookup block is skipped when groupId is absent, so
+     * transfer_data is never added to the PaymentIntent params.
+     */
+    const db = makeDb({
+      receiverUserId: "victim_user_id",
+      stripeAccountId: "acct_victim_stripe",
+    });
+    mockGetSupabase.mockReturnValue(db as unknown as ReturnType<typeof getSupabase>);
+
+    const req = makeRequest({
+      amount: 50,
+      // groupId intentionally omitted — simulates the attack
+      receiverMemberId: "member_victim_id",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // The route must have called paymentIntents.create WITHOUT transfer_data
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    const callArgs = mockPaymentIntentsCreate.mock.calls[0][0] as {
+      transfer_data?: { destination: string };
+    };
+    expect(callArgs.transfer_data).toBeUndefined();
+
+    // The response must report directPayout: false
+    const json = await res.json();
+    expect(json.directPayout).toBe(false);
+  });
+
+  it("does NOT set transfer_data when only receiverMemberId and groupId are present but payerMemberId is omitted", async () => {
+    /**
+     * The auth block requires ALL THREE: groupId + payerMemberId + receiverMemberId.
+     * Omitting payerMemberId bypasses canAccessGroup in the old code — the fix
+     * also guards the Connected Account lookup behind the same three-field condition.
+     */
+    const db = makeDb({
+      receiverUserId: "victim_user_id",
+      stripeAccountId: "acct_victim_stripe",
+    });
+    mockGetSupabase.mockReturnValue(db as unknown as ReturnType<typeof getSupabase>);
+
+    const req = makeRequest({
+      amount: 100,
+      groupId: "group_id_test",
+      // payerMemberId intentionally omitted
+      receiverMemberId: "member_victim_id",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const callArgs = mockPaymentIntentsCreate.mock.calls[0][0] as {
+      transfer_data?: { destination: string };
+    };
+    expect(callArgs.transfer_data).toBeUndefined();
+
+    const json = await res.json();
+    expect(json.directPayout).toBe(false);
+  });
+
+  it("DOES set transfer_data when all three fields are present and auth passes", async () => {
+    /**
+     * Confirms the legitimate path still works after the fix:
+     * when groupId + payerMemberId + receiverMemberId are all present,
+     * canAccessGroup passes, and the receiver has a Connected Account,
+     * transfer_data.destination must be set.
+     */
+    const db = makeDb({
+      receiverUserId: "legit_receiver_user_id",
+      stripeAccountId: "acct_legit_stripe",
+      groupMembersInGroup: [{ id: "member_payer_id" }, { id: "member_receiver_id" }],
+    });
+    mockGetSupabase.mockReturnValue(db as unknown as ReturnType<typeof getSupabase>);
+    mockCanAccessGroup.mockResolvedValue(true);
+
+    const req = makeRequest({
+      amount: 75,
+      groupId: "group_id_legit",
+      payerMemberId: "member_payer_id",
+      receiverMemberId: "member_receiver_id",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const callArgs = mockPaymentIntentsCreate.mock.calls[0][0] as {
+      transfer_data?: { destination: string };
+    };
+    expect(callArgs.transfer_data).toBeDefined();
+    expect(callArgs.transfer_data?.destination).toBe("acct_legit_stripe");
+
+    const json = await res.json();
+    expect(json.directPayout).toBe(true);
+  });
+
+  it("returns 403 when groupId + payerMemberId + receiverMemberId are all present but canAccessGroup rejects", async () => {
+    /**
+     * Confirms that the group auth check still blocks unauthorized requests
+     * when all three fields are provided but the user is not in the group.
+     */
+    const db = makeDb({});
+    mockGetSupabase.mockReturnValue(db as unknown as ReturnType<typeof getSupabase>);
+    mockCanAccessGroup.mockResolvedValue(false);
+
+    const req = makeRequest({
+      amount: 50,
+      groupId: "group_id_forbidden",
+      payerMemberId: "member_payer_id",
+      receiverMemberId: "member_receiver_id",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Forbidden");
+  });
+});

--- a/app/api/stripe/terminal/create-payment-intent/route.ts
+++ b/app/api/stripe/terminal/create-payment-intent/route.ts
@@ -79,7 +79,7 @@ export async function POST(req: NextRequest) {
 
   // Look up the receiver's Stripe Connected Account for direct payouts
   let destinationAccountId: string | null = null;
-  if (body.receiverMemberId) {
+  if (body.receiverMemberId && body.groupId && body.payerMemberId) {
     const { data: receiverMember } = await db
       .from("group_members")
       .select("user_id")

--- a/app/app/subscriptions/__tests__/page.test.ts
+++ b/app/app/subscriptions/__tests__/page.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for BUG-CLIENT-1: Subscriptions page displays USD amounts without currency conversion
+ *
+ * The React component itself cannot be unit-tested in isolation because it
+ * requires Clerk auth context, custom hooks, and Next.js infrastructure.
+ *
+ * Instead, these tests validate the pure utility layer used by the fix:
+ *   - formatCurrency alone does NOT convert currencies (it only formats)
+ *   - convertCurrency produces the correct target-currency numeric value
+ *   - the combined pattern (convertCurrency → formatCurrency) produces the
+ *     correct display string for a non-USD user
+ *
+ * Bug-ID: BUG-CLIENT-1
+ * Severity: P2
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatCurrency, formatCurrencyAbs, convertCurrency } from "@/lib/currency";
+
+// EUR rate: 1 EUR = 1.08 USD, so 1 USD = 1/1.08 EUR ≈ 0.9259 EUR
+// $15.99 USD → 15.99 / 1.08 ≈ 14.8056 EUR
+const USD_AMOUNT = 15.99;
+const EUR_RATE_TO_USD = 1.08;
+const EXPECTED_EUR = USD_AMOUNT / EUR_RATE_TO_USD; // ≈ 14.81
+
+describe("BUG-CLIENT-1: subscriptions page currency conversion", () => {
+  it("formatCurrency alone does NOT convert — it formats the raw number with a different symbol", () => {
+    // Before the fix, the page called fc(amount) without convertCurrency.
+    // For a EUR user, fc() calls formatCurrency(amount, "EUR") which formats
+    // the USD numeric value with the EUR symbol — no conversion.
+    const buggyOutput = formatCurrency(USD_AMOUNT, "EUR");
+    // The buggy output shows the USD numeric value (15.99) with EUR symbol.
+    // It must NOT equal the correctly converted EUR display.
+    const correctOutput = formatCurrency(EXPECTED_EUR, "EUR");
+    expect(buggyOutput).not.toBe(correctOutput);
+  });
+
+  it("convertCurrency converts USD to EUR correctly", () => {
+    const result = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    // 15.99 / 1.08 ≈ 14.8056
+    expect(result).toBeCloseTo(EXPECTED_EUR, 2);
+  });
+
+  it("convertCurrency is a no-op when source and target are the same", () => {
+    const result = convertCurrency(USD_AMOUNT, "USD", "USD");
+    expect(result).toBe(USD_AMOUNT);
+  });
+
+  it("combined pattern (convertCurrency then formatCurrency) produces correct EUR display string", () => {
+    const converted = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    const displayed = formatCurrency(converted, "EUR");
+    // The correctly converted and formatted EUR amount should NOT contain $15.99
+    expect(displayed).not.toContain("15,99");
+    // It should represent the converted value (~14.81)
+    expect(displayed).toContain("14,8");
+  });
+
+  it("formatCurrencyAbs without conversion shows wrong value for non-USD users", () => {
+    // Before fix: fca(sub.amount) with EUR user shows $15.99 formatted as EUR
+    const buggyOutput = formatCurrencyAbs(USD_AMOUNT, "EUR");
+    const correctOutput = formatCurrencyAbs(convertCurrency(USD_AMOUNT, "USD", "EUR"), "EUR");
+    expect(buggyOutput).not.toBe(correctOutput);
+  });
+
+  it("combined pattern with formatCurrencyAbs produces correct EUR absolute display", () => {
+    const converted = convertCurrency(USD_AMOUNT, "USD", "EUR");
+    const displayed = formatCurrencyAbs(converted, "EUR");
+    expect(displayed).toContain("14,8");
+  });
+});

--- a/app/app/subscriptions/page.tsx
+++ b/app/app/subscriptions/page.tsx
@@ -4,6 +4,7 @@ import { RefreshCw, HelpCircle } from "lucide-react";
 import { motion } from "motion/react";
 import { useSubscriptions } from "@/hooks/useSubscriptions";
 import { useCurrency } from "@/hooks/useCurrency";
+import { convertCurrency } from "@/lib/currency";
 
 function MerchantAvatar({ name, color }: { name: string; color: string }) {
   return (
@@ -18,7 +19,7 @@ function MerchantAvatar({ name, color }: { name: string; color: string }) {
 
 export default function SubscriptionsPage() {
   const { subscriptions, totalMonthly, totalAnnual, loading, detecting, error, detect, dismiss, dismissPriceChange } = useSubscriptions();
-  const { format: fc, formatAbs: fca } = useCurrency();
+  const { format: fc, formatAbs: fca, currencyCode } = useCurrency();
 
   if (loading) {
     return (
@@ -47,7 +48,7 @@ export default function SubscriptionsPage() {
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 tracking-tight">Subscriptions</h1>
         <p className="text-sm text-gray-500 mt-1">
-          {subscriptions.length} active · {fc(totalMonthly)}/mo · {fc(totalAnnual)}/yr
+          {subscriptions.length} active · {fc(convertCurrency(totalMonthly, "USD", currencyCode))}/mo · {fc(convertCurrency(totalAnnual, "USD", currencyCode))}/yr
         </p>
       </div>
       <button
@@ -71,11 +72,11 @@ export default function SubscriptionsPage() {
           <div className="grid grid-cols-2 gap-4 mb-6">
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Monthly</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalMonthly)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalMonthly, "USD", currencyCode))}</div>
             </div>
             <div className="bg-white rounded-2xl border border-gray-100 p-4">
               <div className="text-xs text-gray-400 mb-1">Annual</div>
-              <div className="text-xl font-bold text-gray-900">{fc(totalAnnual)}</div>
+              <div className="text-xl font-bold text-gray-900">{fc(convertCurrency(totalAnnual, "USD", currencyCode))}</div>
             </div>
           </div>
           <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
@@ -108,7 +109,7 @@ export default function SubscriptionsPage() {
                         }`}
                         title="Click to dismiss"
                       >
-                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(sub.priceChange.change)}
+                        {sub.priceChange.change > 0 ? "↑" : "↓"} {fca(convertCurrency(sub.priceChange.change, "USD", currencyCode))}
                       </button>
                     )}
                   </div>
@@ -118,7 +119,7 @@ export default function SubscriptionsPage() {
                 </div>
                 <div className="text-right shrink-0">
                   <div className="text-sm font-bold text-gray-900">
-                    {fca(sub.amount)}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
+                    {fca(convertCurrency(sub.amount, "USD", currencyCode))}/{sub.frequency === "yearly" ? "yr" : sub.frequency === "semiannual" ? "6mo" : sub.frequency === "quarterly" ? "qtr" : sub.frequency === "biweekly" ? "2wk" : sub.frequency === "weekly" ? "wk" : "mo"}
                   </div>
                 </div>
                 <button
@@ -159,7 +160,7 @@ export default function SubscriptionsPage() {
                     <div key={sub.id}>
                       <div className="flex items-center justify-between text-xs mb-1">
                         <span className="text-gray-600">{sub.merchant}</span>
-                        <span className="text-gray-500">{fc(yearly)}/yr</span>
+                        <span className="text-gray-500">{fc(convertCurrency(yearly, "USD", currencyCode))}/yr</span>
                       </div>
                       <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
                         <motion.div

--- a/lib/__tests__/subscription-detect.test.ts
+++ b/lib/__tests__/subscription-detect.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockSelectResult = vi.fn();
 const mockUpdateResult = vi.fn();
 const mockUpsertResult = vi.fn();
+const mockDeleteResult = vi.fn();
 
 /**
  * Build a fully chainable Supabase query builder that terminates with a
@@ -36,11 +37,14 @@ vi.mock("../supabase", () => ({
       if (table === "subscriptions") {
         return {
           // Phase 1 select — batch fetch existing subs: .select().eq().in()
+          // Also used by deleteExcludedSubscriptions SELECT
           select: () => makeChainable(mockSelectResult),
           // Update path (Phase 2)
           update: (_data: unknown) => makeChainable(mockUpdateResult),
           // Upsert path (Phase 2 new subs, and Phase 3 subscription_transactions)
           upsert: (_rows: unknown, _opts?: unknown) => makeChainable(mockUpsertResult),
+          // Delete path (deleteExcludedSubscriptions)
+          delete: () => makeChainable(mockDeleteResult),
         };
       }
       // subscription_transactions and transactions tables — safe no-ops
@@ -54,7 +58,7 @@ vi.mock("../supabase", () => ({
   }),
 }));
 
-import { saveDetectedSubscriptions } from "../subscription-detect";
+import { saveDetectedSubscriptions, deleteExcludedSubscriptions } from "../subscription-detect";
 import type { DetectedSubscription } from "../subscription-detect";
 
 function makeDetected(overrides?: Partial<DetectedSubscription>): DetectedSubscription {
@@ -181,5 +185,30 @@ describe("saveDetectedSubscriptions — error propagation (BUG-RESILIENCE-1)", (
       expect(mockUpdateResult).not.toHaveBeenCalled();
       expect(mockUpsertResult).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("deleteExcludedSubscriptions — SELECT error propagation (BUG-RESILIENCE-1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when the Supabase SELECT returns an error instead of silently returning 0", async () => {
+    // Mock the SELECT to return an error (e.g. connection timeout)
+    mockSelectResult.mockResolvedValue({
+      data: null,
+      error: { message: "connection timeout" },
+    });
+
+    await expect(deleteExcludedSubscriptions("user-1")).rejects.toThrow(
+      "Failed to load subscriptions: connection timeout"
+    );
+  });
+
+  it("returns 0 when SELECT succeeds but there are no active subscriptions", async () => {
+    mockSelectResult.mockResolvedValue({ data: [], error: null });
+
+    const result = await deleteExcludedSubscriptions("user-1");
+    expect(result).toBe(0);
   });
 });

--- a/lib/subscription-detect.ts
+++ b/lib/subscription-detect.ts
@@ -13,11 +13,12 @@ import { matchKnownSubscription } from "./known-subscriptions";
 
 export async function deleteExcludedSubscriptions(clerkUserId: string): Promise<number> {
   const db = getSupabase();
-  const { data: rows } = await db
+  const { data: rows, error } = await db
     .from("subscriptions")
     .select("id, merchant_name, primary_category")
     .eq("clerk_user_id", clerkUserId)
     .eq("status", "active");
+  if (error) throw new Error(`Failed to load subscriptions: ${error.message}`);
   if (!rows?.length) return 0;
   const toDelete = rows.filter((r) =>
     shouldExcludeAsSubscription(r.primary_category, r.merchant_name ?? "", "")


### PR DESCRIPTION
## Bug Council Audit Results

**Bugs reported by agents**: 3 (unique after deduplication across 5 agents)
**Bugs verified (survived Devil's Advocate)**: 3
**Bugs fixed (with tests)**: 3
**Bugs deferred**: 0
**False positives rejected**: 0

## Fixed Bugs

### P1 — Broken Functionality / Security

**BUG-CRITICAL-1**: Stripe Terminal `create-payment-intent` Connected Account lookup runs without group auth when `groupId` is omitted — `app/api/stripe/terminal/create-payment-intent/route.ts`
- The `if (body.receiverMemberId)` block ran independently of `body.groupId`, bypassing `canAccessGroup` while still setting `transfer_data.destination` to an arbitrary platform member's Stripe Connected Account. Fixed by guarding the block with `if (body.receiverMemberId && body.groupId && body.payerMemberId)` to match the auth block condition.
- Test: `app/api/stripe/terminal/__tests__/create-payment-intent.test.ts` (4 new tests)

**BUG-RESILIENCE-1**: `deleteExcludedSubscriptions` in `lib/subscription-detect.ts` silently swallowed Supabase SELECT errors — `lib/subscription-detect.ts`
- Missing `{ error }` destructure from `.select()`. On DB error, `rows` was `null`, `!rows?.length` evaluated to `true`, and the function returned `0` instead of propagating the failure. This was a previously fixed regression (Pattern Rule #1 from MEMORY.md — fix reverted by commit `93a9b5c`).
- Test: `lib/__tests__/subscription-detect.test.ts` (+2 tests)

### P2 — Incorrect Behavior

**BUG-CLIENT-1**: Currency conversion stripped from subscriptions page — 4th regression — `app/app/subscriptions/page.tsx`
- All `convertCurrency()` calls and the `currencyCode` destructure were removed. Non-USD users saw raw USD amounts reformatted with their currency symbol (e.g., C$15.99 instead of C$21.61 for a Canadian user). Restored `import { convertCurrency }`, `currencyCode` from `useCurrency()`, and 6 call sites. Test file also recreated (was deleted in the same regression commit).
- Test: `app/app/subscriptions/__tests__/page.test.ts` (+6 tests, recreated)

## Tests Added
- `app/api/stripe/terminal/__tests__/create-payment-intent.test.ts` — 4 tests: bypass without groupId, bypass without payerMemberId, legitimate path works, auth rejection
- `lib/__tests__/subscription-detect.test.ts` — +2 tests: SELECT error throws, empty result still returns 0
- `app/app/subscriptions/__tests__/page.test.ts` — 6 tests: currency conversion correctness (recreated after deletion)

## Deferred Bugs (Not Fixed)
None.

## Disproved Bugs (Rejected by Devil's Advocate)
None — all 3 reported bugs were confirmed.

## Root Cause Note
Commit `93a9b5c` ("chore: trigger deploy for Stripe live keys") secretly reverted 4 files, hiding two bug fixes (subscriptions page currency conversion, subscription-detect SELECT error handling). The Stripe Terminal auth bug was a pre-existing issue unrelated to recent changes.

## Patterns Found
- **Currency conversion stripping** (4th recurrence): `convertCurrency()` before `formatCurrency()` — already in `.cursor/rules/common-bugs.mdc` line 12
- **SELECT error not destructured** (2nd occurrence in subscription-detect): Updated `.cursor/rules/common-bugs.mdc` to include `.select()` alongside `.update()/.insert()/.delete()`

## Verification
- [x] `npm run typecheck` — passes (no new errors vs baseline)
- [x] `npm run lint` — passes (70 warnings same as baseline, 0 errors)
- [x] `npm run test` — passes (63 files, 634 tests — 12 new tests added, all green; baseline was 61 files, 622 tests)

---
Generated by Bug Council v2 (evidence-based)