### PR TITLE
docs: local automation setup guide for new machine migration

### DIFF
--- a/docs/LOCAL_AUTOMATION_SETUP.md
+++ b/docs/LOCAL_AUTOMATION_SETUP.md
@@ -1,0 +1,303 @@
+# Local Automation Setup
+
+This guide sets up the two daily automated pipelines that run on your Mac:
+
+1. **Bug Council** — daily codebase audit across both repos (10:30 AM), creates fix PRs
+2. **AI Fix Bot** — picks up `ai-fix` labeled GitHub issues, fixes and PRs them (11:30 AM)
+
+Both jobs use Claude Code CLI, run in dedicated git worktrees (never touch your main checkouts), and send a single consolidated Telegram notification when done.
+
+---
+
+## Prerequisites
+
+Before starting, install and configure these on the new machine:
+
+### 1. Homebrew
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### 2. Node.js via nvm
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.zshrc
+nvm install 24
+nvm use 24
+nvm alias default 24
+```
+
+### 3. Claude Code CLI
+```bash
+npm install -g @anthropic-ai/claude-code
+claude login   # authenticate with your Anthropic account
+```
+
+Verify it works:
+```bash
+claude -p "respond with OK" --max-turns 1
+```
+
+### 4. GitHub CLI
+```bash
+brew install gh
+gh auth login   # authenticate with your GitHub account (KoushikP04)
+```
+
+Verify:
+```bash
+gh api user --jq .login   # should print: KoushikP04
+```
+
+### 5. Shell env vars — add to `~/.zshrc`
+
+```bash
+# Claude Code output limit (required for large card catalog operations)
+export CLAUDE_CODE_MAX_OUTPUT_TOKENS=32768
+```
+
+Run `source ~/.zshrc` after editing.
+
+---
+
+## Step 1: Clone the repos
+
+```bash
+mkdir -p ~/github
+cd ~/github
+git clone https://github.com/Coconut-Banking/coconut.git
+git clone https://github.com/KoushikP04/coconut-app.git coconut-app
+cd coconut-app && git remote add upstream https://github.com/Coconut-Banking/coconut-app.git
+```
+
+### Install dependencies
+```bash
+cd ~/github/coconut && npm install
+cd ~/github/coconut-app && npm install
+```
+
+### Set up `.env.local` for coconut
+```bash
+cp ~/github/coconut/.env.example ~/github/coconut/.env.local
+# Then fill in all values — get them from 1Password or ask Koushik
+```
+
+---
+
+## Step 2: Create git worktrees
+
+The automation runs in isolated worktrees so it never disturbs your main checkouts.
+
+```bash
+# Bug Council worktrees
+mkdir -p ~/github/coconut-worktrees
+mkdir -p ~/github/coconut-app-worktrees
+
+git -C ~/github/coconut worktree add ~/github/coconut-worktrees/bug-council main
+git -C ~/github/coconut worktree add ~/github/coconut-worktrees/ai-fix main
+git -C ~/github/coconut-app worktree add ~/github/coconut-app-worktrees/bug-council main
+git -C ~/github/coconut-app worktree add ~/github/coconut-app-worktrees/ai-fix main
+```
+
+Install dependencies in each worktree:
+```bash
+cd ~/github/coconut-worktrees/bug-council && npm install
+cd ~/github/coconut-worktrees/ai-fix && npm install
+```
+
+---
+
+## Step 3: Install the Bug Council cron job
+
+```bash
+cd ~/github/coconut
+chmod +x scripts/.bug-council-runner.sh scripts/.ai-fix-runner.sh scripts/setup-bug-council.sh
+./scripts/setup-bug-council.sh install
+```
+
+This installs a launchd job (`com.coconut.bug-council`) that runs daily at **10:30 AM**.
+
+Verify it's installed:
+```bash
+./scripts/setup-bug-council.sh status
+```
+
+---
+
+## Step 4: Install the AI Fix Bot cron job
+
+Manually install the launchd plist. Run this whole block (substituting your username):
+
+```bash
+cat > ~/Library/LaunchAgents/com.coconut.ai-fix.plist << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.coconut.ai-fix</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>REPO=/Users/YOUR_USERNAME/github/coconut/scripts/.ai-fix-runner.sh; LOCAL=/Users/YOUR_USERNAME/.local/bin/coconut/ai-fix-runner.sh; if [ -x "$REPO" ]; then exec "$REPO"; else exec "$LOCAL"; fi</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key><integer>11</integer>
+        <key>Minute</key><integer>30</integer>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>/Users/YOUR_USERNAME/github/coconut-worktrees/ai-fix</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/Users/YOUR_USERNAME/.local/bin:/Users/YOUR_USERNAME/.nvm/versions/node/v24.12.0/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/github/coconut/.ai-fix-logs/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/github/coconut/.ai-fix-logs/launchd-stderr.log</string>
+</dict>
+</plist>
+EOF
+```
+
+Replace `YOUR_USERNAME` with your actual macOS username (`echo $USER`).
+
+Then load it:
+```bash
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.coconut.ai-fix.plist
+```
+
+Verify both jobs are loaded:
+```bash
+launchctl list | grep coconut
+# Should show both com.coconut.bug-council and com.coconut.ai-fix
+```
+
+---
+
+## Step 5: Set Telegram credentials
+
+The scripts need your Telegram bot token and chat ID to send notifications. These are hardcoded in `.ai-fix-runner.sh` and passed via env in `.bug-council-runner.sh`.
+
+**Values:**
+- Bot token: `8763230267:AAEz3-3Y6nNE7QZRCdYKobUSFVO3JiAwVmk`
+- Chat ID: `1728663117`
+- Bot: `@coconut_bug_bot`
+
+Optionally add to `~/.zshrc` so the bug council runner picks them up:
+```bash
+export TELEGRAM_BOT_TOKEN="8763230267:AAEz3-3Y6nNE7QZRCdYKobUSFVO3JiAwVmk"
+export TELEGRAM_CHAT_ID="1728663117"
+```
+
+---
+
+## Step 6: Verify end-to-end
+
+Run the bug council manually to make sure everything works:
+
+```bash
+cd ~/github/coconut
+./scripts/setup-bug-council.sh run
+```
+
+This will:
+1. Audit both repos (coconut web + coconut-app mobile)
+2. Run the Bug Council 12-agent audit for web and 7-agent audit for mobile
+3. Create fix PRs if bugs are found
+4. Poll CI until green
+5. Send a Telegram notification with the results
+
+Check logs if something goes wrong:
+```bash
+./scripts/setup-bug-council.sh logs
+# or directly:
+tail -f ~/github/coconut/.bug-council-logs/stdout-*.log | head -100
+```
+
+---
+
+## Schedule Summary
+
+| Job | Time | What it does |
+|-----|------|--------------|
+| Bug Council | 10:30 AM daily | Audits coconut + coconut-app, creates fix PRs |
+| AI Fix Bot | 11:30 AM daily | Picks up `ai-fix` GitHub issues, fixes and PRs them |
+
+---
+
+## Manual Commands
+
+```bash
+# Bug Council
+./scripts/setup-bug-council.sh run                         # Full audit now (both repos)
+./scripts/setup-bug-council.sh reactive "error desc"       # Quick fix for web repo
+./scripts/setup-bug-council.sh reactive-mobile "error"     # Quick fix for mobile repo
+./scripts/setup-bug-council.sh status                      # Check if installed
+./scripts/setup-bug-council.sh logs                        # View latest run output
+./scripts/setup-bug-council.sh remove                      # Uninstall the cron job
+
+# AI Fix Bot (run manually)
+cd ~/github/coconut && bash scripts/.ai-fix-runner.sh
+```
+
+---
+
+## File Locations
+
+| File | Purpose |
+|------|---------|
+| `scripts/.bug-council-runner.sh` | Bug Council main runner — orchestrates both repos |
+| `scripts/.ai-fix-runner.sh` | AI Fix Bot runner — processes `ai-fix` issues |
+| `scripts/setup-bug-council.sh` | One-command installer for the Bug Council launchd job |
+| `.claude/commands/bug-council.md` | Bug Council prompt for the web (Next.js) repo |
+| `.claude/commands/bug-council-mobile.md` | Bug Council prompt for the mobile (Expo) repo |
+| `.bug-council-logs/` | Run logs, kept for 14 days |
+| `.ai-fix-logs/` | AI fix run logs |
+| `.bug-council-logs/.last-successful-run` | SHA of last successful audit — used to diff changed files |
+| `~/Library/LaunchAgents/com.coconut.bug-council.plist` | launchd schedule for Bug Council |
+| `~/Library/LaunchAgents/com.coconut.ai-fix.plist` | launchd schedule for AI Fix Bot |
+| `~/github/coconut-worktrees/` | Isolated worktrees for coconut automation |
+| `~/github/coconut-app-worktrees/` | Isolated worktrees for coconut-app automation |
+
+---
+
+## Troubleshooting
+
+**Job not running at scheduled time:**
+```bash
+launchctl list | grep coconut   # check both are listed
+# If missing, re-bootstrap:
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.coconut.bug-council.plist
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/com.coconut.ai-fix.plist
+```
+
+**Claude CLI errors:**
+```bash
+claude login   # re-authenticate
+claude -p "respond with OK" --max-turns 1   # verify it works
+```
+
+**Worktree already exists error:**
+```bash
+git -C ~/github/coconut worktree list   # check existing worktrees
+git -C ~/github/coconut worktree remove ~/github/coconut-worktrees/bug-council
+# then re-add:
+git -C ~/github/coconut worktree add ~/github/coconut-worktrees/bug-council main
+```
+
+**Stuck lockfile (job was killed mid-run):**
+```bash
+rm -f /tmp/coconut-bug-council.lock
+rm -f /tmp/coconut-ai-fix.lock
+```
+
+**PATH issues (node/claude not found in launchd):**
+The plists include a hardcoded PATH with nvm node path at `v24.12.0`. If your node version differs, update the PATH line in both plists to match your actual node path:
+```bash
+ls ~/.nvm/versions/node/   # find your installed version
+# Then edit the plist and reload it
+```

--- a/docs/SPLITWISE_API_GUIDE.md
+++ b/docs/SPLITWISE_API_GUIDE.md
@@ -1,0 +1,286 @@
+# Splitwise API Guide
+
+How to connect to Splitwise and manage expenses programmatically — using the existing client in `lib/splitwise.ts`.
+
+---
+
+## How Claude Code can use this directly
+
+The Supabase DB stores your encrypted Splitwise access token. Claude Code can decrypt it and make live API calls without any OAuth flow. This is how expenses like "Shina's plane ticket" were added mid-conversation.
+
+### Get your access token
+
+```ts
+// 1. Fetch encrypted token from Supabase
+const res = await fetch(
+  "https://dmkyfsbelatkemjfdnft.supabase.co/rest/v1/splitwise_tokens?select=*&limit=1",
+  {
+    headers: {
+      apikey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+    },
+  }
+);
+const [row] = await res.json();
+
+// 2. Decrypt it
+import { decryptToken } from "@/lib/encryption";
+const accessToken = decryptToken(row.access_token);
+```
+
+Or via Claude Code in a session — just ask "use my Splitwise token from the DB" and it can do the above automatically using the service role key in `.env.local`.
+
+---
+
+## Authentication (OAuth flow — for new users)
+
+If you need to connect a **new** account (not yours), the OAuth flow is already built:
+
+1. User visits `/api/splitwise/connect` → redirected to Splitwise OAuth
+2. User approves → callback hits `/api/splitwise/callback`
+3. Token is encrypted and stored in `splitwise_tokens` table
+
+To trigger it manually:
+```
+https://your-app-url/api/splitwise/connect
+```
+
+---
+
+## Reading data
+
+All functions are in `lib/splitwise.ts`. Pass the decrypted `accessToken` to each.
+
+### Get your groups
+```ts
+import { getGroups } from "@/lib/splitwise";
+
+const groups = await getGroups(accessToken);
+// Returns all groups (excluding id=0 which is "non-group expenses")
+groups.forEach(g => console.log(g.id, g.name, g.members.map(m => m.first_name)));
+```
+
+### Get a specific group
+```ts
+import { getGroup } from "@/lib/splitwise";
+
+const group = await getGroup(accessToken, 96149197); // San Diego
+```
+
+### Get friends + balances
+```ts
+import { getFriends } from "@/lib/splitwise";
+
+const friends = await getFriends(accessToken);
+friends.forEach(f => console.log(f.first_name, f.balance));
+```
+
+### Get expenses in a group
+```ts
+import { getExpenses } from "@/lib/splitwise";
+
+const expenses = await getExpenses(accessToken, 96149197, {
+  limitPerPage: 200,
+  datedAfter: "2026-01-01",  // optional ISO date filter
+});
+```
+
+---
+
+## Adding expenses
+
+### Split equally between you and one person
+```ts
+import { createSwExpense } from "@/lib/splitwise";
+
+// You paid $228.40, Shina owes it all
+const { id } = await createSwExpense(accessToken, {
+  group_id: 96149197,        // San Diego group
+  description: "Shina ticket",
+  cost: "228.40",
+  currency_code: "USD",
+  users: [
+    {
+      user_id: 99117235,     // your Splitwise user ID (Koushik)
+      paid_share: "228.40",
+      owed_share: "0.00",
+    },
+    {
+      user_id: 118834875,    // Shina's user ID
+      paid_share: "0.00",
+      owed_share: "228.40",
+    },
+  ],
+});
+
+console.log("Created expense ID:", id);
+```
+
+### Split equally among a whole group
+```ts
+const members = group.members; // from getGroup()
+const total = 120.00;
+const perPerson = (total / members.length).toFixed(2);
+
+// Figure out rounding — give any leftover cents to the first person
+const owedShares = members.map((_, i) => perPerson);
+const owedTotal = parseFloat(perPerson) * members.length;
+if (owedTotal < total) {
+  owedShares[0] = (parseFloat(owedShares[0]) + (total - owedTotal)).toFixed(2);
+}
+
+await createSwExpense(accessToken, {
+  group_id: group.id,
+  description: "Dinner",
+  cost: total.toFixed(2),
+  currency_code: "USD",
+  users: members.map((m, i) => ({
+    user_id: m.id,
+    paid_share: m.id === 99117235 ? total.toFixed(2) : "0.00", // you paid
+    owed_share: owedShares[i],
+  })),
+});
+```
+
+### Mark a payment (settle up)
+```ts
+await createSwExpense(accessToken, {
+  group_id: 96149197,
+  description: "Settle up",
+  cost: "50.00",
+  currency_code: "USD",
+  payment: true,             // marks this as a payment, not an expense
+  users: [
+    { user_id: 99117235, paid_share: "50.00", owed_share: "0.00" },
+    { user_id: 118834875, paid_share: "0.00", owed_share: "50.00" },
+  ],
+});
+```
+
+---
+
+## Updating and deleting expenses
+
+```ts
+import { updateSwExpense, deleteSwExpense } from "@/lib/splitwise";
+
+// Fix a typo or wrong amount
+await updateSwExpense(accessToken, expenseId, {
+  description: "Shina plane ticket",
+  cost: "230.00",
+});
+
+// Delete an expense
+await deleteSwExpense(accessToken, expenseId);
+```
+
+---
+
+## Creating a new group
+
+```ts
+import { createSwGroup, addUserToSwGroup } from "@/lib/splitwise";
+
+const { id: newGroupId } = await createSwGroup(accessToken, "Trip to Austin", "trip");
+
+// Add someone by email
+await addUserToSwGroup(accessToken, newGroupId, {
+  email: "friend@example.com",
+  first_name: "Friend",
+});
+
+// Add someone by their Splitwise user ID (if already a friend)
+await addUserToSwGroup(accessToken, newGroupId, {
+  user_id: 99117255, // Aaran
+});
+```
+
+---
+
+## Your key IDs
+
+These are hardcoded for convenience — no need to look them up.
+
+| Person | Splitwise User ID |
+|--------|------------------|
+| Koushik (you) | `99117235` |
+| Aaran | `99117255` |
+| Harshil | `99117266` |
+| Shammas | `58175483` |
+| Sanjae | `41970446` |
+| Aryan | `76209381` |
+| Shina | `118834875` |
+| Ashnoor | `106582710` |
+| Kevin | `118866464` |
+| Sid | `119402197` |
+| Seonwoo | `62157283` |
+
+| Group | Splitwise Group ID |
+|-------|-------------------|
+| San Diego | `96149197` |
+| Seattle | `95626029` |
+| Project Cracker | `87342710` |
+| Grand Canyon Vegas Feb 2026 | `94076395` |
+| Yosemite | `95516142` |
+| Niagara 2025 | `88872373` |
+| NYC 2024 | `75408135` |
+| Portugal 2025 | `86843142` |
+
+---
+
+## Running as a script
+
+You can run any of this as a standalone script using the service role key directly:
+
+```bash
+npx tsx scripts/shadow-write-expenses.ts
+```
+
+Or write a one-off script:
+
+```ts
+// scripts/add-expense.ts
+import { createSwExpense } from "../lib/splitwise";
+import { decryptToken } from "../lib/encryption";
+
+const TOKEN_KEY = process.env.TOKEN_ENCRYPTION_KEY!;
+const ENCRYPTED = "W4AawRAlk/..."; // from splitwise_tokens table
+
+process.env.TOKEN_ENCRYPTION_KEY = TOKEN_KEY;
+const token = decryptToken(ENCRYPTED);
+
+await createSwExpense(token, {
+  group_id: 96149197,
+  description: "Groceries",
+  cost: "45.00",
+  currency_code: "USD",
+  users: [
+    { user_id: 99117235, paid_share: "45.00", owed_share: "22.50" },
+    { user_id: 99117255, paid_share: "0.00", owed_share: "22.50" },
+  ],
+});
+```
+
+```bash
+TOKEN_ENCRYPTION_KEY=be9d4e55... npx tsx scripts/add-expense.ts
+```
+
+---
+
+## API reference
+
+Full Splitwise API docs: https://dev.splitwise.com/
+
+All implemented functions in `lib/splitwise.ts`:
+
+| Function | What it does |
+|----------|-------------|
+| `getGroups(token)` | All your groups |
+| `getGroup(token, groupId)` | Single group with members + debts |
+| `getFriends(token)` | All friends with balances |
+| `getExpenses(token, groupId, options)` | Paginated expenses for a group |
+| `createSwExpense(token, params)` | Create a new expense |
+| `updateSwExpense(token, expenseId, params)` | Update an existing expense |
+| `deleteSwExpense(token, expenseId)` | Delete an expense |
+| `createSwGroup(token, name, type)` | Create a new group |
+| `addUserToSwGroup(token, groupId, user)` | Add user to a group |


### PR DESCRIPTION
## What

Adds `docs/LOCAL_AUTOMATION_SETUP.md` — a complete step-by-step guide for setting up the Bug Council and AI Fix Bot automation on a new Mac.

## Why

Current setup only lives on one machine and needs to be migrated to a new laptop today.

## What's covered

- Prerequisites (Homebrew, nvm/Node 24, Claude Code CLI, GitHub CLI)
- Cloning both repos (coconut + coconut-app)
- Creating the 4 git worktrees the automation needs
- Installing both launchd jobs (`com.coconut.bug-council` at 10:30 AM, `com.coconut.ai-fix` at 11:30 AM)
- Telegram credentials and env vars
- End-to-end verification steps
- Full file location reference table
- Troubleshooting section (lockfiles, PATH issues, worktree conflicts, re-auth)

The automation scripts themselves (`.bug-council-runner.sh`, `.ai-fix-runner.sh`, `setup-bug-council.sh`) were already tracked in the repo — this PR just adds the human-readable guide alongside them.