### PR TITLE
Production hardening and race-safe settlements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ SUPABASE_SERVICE_ROLE_KEY=eyJ...
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...
 CLERK_SECRET_KEY=sk_...
 # Clerk webhooks (for user.deleted offboarding) — from Webhooks → endpoint → Signing Secret
-# CLERK_WEBHOOK_SIGNING_SECRET=whsec_...
+CLERK_WEBHOOK_SIGNING_SECRET=whsec_...
 
 # Skip auth for local/dev testing (bypasses sign-in; APIs use first DB user)
 # NEXT_PUBLIC_SKIP_AUTH=true
@@ -107,3 +107,44 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 # Fine-grained PAT with Issues: Read & Write on Coconut-Banking/coconut-app
 # Create at https://github.com/settings/tokens?type=beta
 GITHUB_BOT_TOKEN=ghp_...
+
+# --- Production operations (Vercel) ---
+
+# Vercel Cron auth — REQUIRED in production. Vercel sends Authorization: Bearer <CRON_SECRET>
+# on /api/cron/process-jobs (every minute) and /api/cron/receipt-match (daily).
+# Generate: openssl rand -hex 32
+CRON_SECRET=
+
+# RevenueCat webhook (optional — only when enabling paid Pro tier)
+# Dashboard → Project → Integrations → Webhooks → Authorization header Bearer token.
+# REVENUECAT_WEBHOOK_SECRET=
+
+# Signed pay/collect links — use dedicated keys (do NOT reuse CLERK_SECRET_KEY).
+# Generate each: openssl rand -hex 32
+PAY_LINK_SIGNING_KEY=
+COLLECT_LINK_SIGNING_KEY=
+
+# Universal Links (apple-app-site-association). Defaults to 942BUGUD75 if unset.
+APPLE_TEAM_ID=942BUGUD75
+
+# Debug API routes (/api/debug/*, /api/plaid/debug). Must be unset or "false" in production.
+# ENABLE_DEBUG_ENDPOINTS=true
+
+# Demo API (/api/demo). Only works when NODE_ENV !== production AND DEMO_ENABLED=true.
+# DEMO_ENABLED=true
+
+# Telegram bug-report bot (optional)
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_WEBHOOK_SECRET=
+
+# Stripe Connect / Terminal thin webhook (optional second endpoint)
+# STRIPE_WEBHOOK_SECRET_THIN=whsec_...
+
+# Upstash Redis for distributed rate limiting (optional; in-memory fallback if unset)
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+
+# Sentry (optional — recommended for production)
+# SENTRY_DSN=
+# NEXT_PUBLIC_SENTRY_DSN=
+# SENTRY_AUTH_TOKEN=

--- a/app/api/__tests__/expense-settlement-flows.test.ts
+++ b/app/api/__tests__/expense-settlement-flows.test.ts
@@ -17,6 +17,8 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { computePairwiseBalance } from "@/lib/split-balances";
+import { splitTransactionDedupeKey } from "@/lib/split-transaction-helpers";
 
 const TEST_USER_ID = "test_user_flows";
 
@@ -57,6 +59,81 @@ function nextId(prefix: string) {
 }
 
 type MockListResult = { data: Record<string, unknown>[]; error: null };
+
+/** Mirrors get_pairwise_settlement_max / getMaxSettlementAllowed for mock RPC cap. */
+function mockPairwiseSettlementMax(
+  groupId: string,
+  receiverMemberId: string,
+  payerMemberId: string,
+  currency = "USD",
+): number {
+  const group = db.groups.find((g) => g.id === groupId);
+  const isSwGroup =
+    (group as { source?: string } | undefined)?.source === "splitwise" &&
+    !!(group as { external_id?: string } | undefined)?.external_id;
+
+  const filtered = (db.split_transactions ?? []).filter((s) => {
+    if ((s as { group_id?: string }).group_id !== groupId) return false;
+    if (isSwGroup && (s as { source?: string | null }).source === "splitwise") return false;
+    return true;
+  });
+
+  const seenKeys = new Set<string>();
+  const splits = filtered.filter((s) => {
+    const k = splitTransactionDedupeKey(s as { id: string; transaction_id?: string | null });
+    if (seenKeys.has(k)) return false;
+    seenKeys.add(k);
+    return true;
+  });
+
+  const splitCurrencyById = new Map(
+    splits.map((s) => [
+      s.id as string,
+      String((s as { iso_currency_code?: string }).iso_currency_code ?? "USD").toUpperCase(),
+    ]),
+  );
+
+  const sharesBySplitId = new Map<string, Array<{ member_id: string; amount: number }>>();
+  for (const sh of db.split_shares ?? []) {
+    const splitId = sh.split_transaction_id as string;
+    const list = sharesBySplitId.get(splitId);
+    const row = { member_id: sh.member_id as string, amount: Number(sh.amount) };
+    if (list) list.push(row);
+    else sharesBySplitId.set(splitId, [row]);
+  }
+
+  const nativeSettlements = (db.settlements ?? []).filter((s) => {
+    if ((s as { group_id?: string }).group_id !== groupId) return false;
+    if ((s as { status?: string }).status !== "completed") return false;
+    if (isSwGroup && (s as { method?: string }).method === "splitwise") return false;
+    return true;
+  });
+
+  const pairwiseSplits = splits.map((s) => ({
+    id: s.id as string,
+    payerMemberId: (s as { payer_member_id?: string | null }).payer_member_id ?? null,
+  }));
+
+  const pairwiseSettlements = nativeSettlements.map((s) => ({
+    payer_member_id: s.payer_member_id as string,
+    receiver_member_id: s.receiver_member_id as string,
+    amount: Number(s.amount),
+    currency: String((s as { iso_currency_code?: string }).iso_currency_code ?? "USD").toUpperCase(),
+  }));
+
+  return Math.max(
+    0,
+    computePairwiseBalance(
+      receiverMemberId,
+      payerMemberId,
+      pairwiseSplits,
+      sharesBySplitId,
+      pairwiseSettlements,
+      splitCurrencyById,
+      currency.toUpperCase(),
+    ),
+  );
+}
 
 function rpcHandler(
   fnName: string,
@@ -247,13 +324,38 @@ function rpcHandler(
       }
     }
 
+    const maxAmount = mockPairwiseSettlementMax(
+      groupId,
+      receiverMemberId,
+      payerMemberId,
+      currency,
+    );
+
+    if (maxAmount < 0.01) {
+      return {
+        data: {
+          error: "Already settled between these members in this currency",
+          max_amount: maxAmount,
+        },
+        error: null,
+      };
+    }
+
+    const insertAmount = Math.min(Math.round(amount * 100) / 100, maxAmount);
+    if (insertAmount < 0.01) {
+      return {
+        data: { error: "Amount too small", max_amount: maxAmount },
+        error: null,
+      };
+    }
+
     const settId = nextId("set");
     db.settlements.push({
       id: settId,
       group_id: groupId,
       payer_member_id: payerMemberId,
       receiver_member_id: receiverMemberId,
-      amount,
+      amount: insertAmount,
       iso_currency_code: currency,
       status: "completed",
       method: fnName === "insert_stripe_settlement_checked" ? "stripe" : "manual",
@@ -261,7 +363,7 @@ function rpcHandler(
       ...(externalRef ? { external_reference: externalRef } : {}),
     });
 
-    return { data: { id: settId, amount }, error: null };
+    return { data: { id: settId, amount: insertAmount }, error: null };
   }
 
   return { data: null, error: { message: `Unknown RPC: ${fnName}` } };
@@ -561,6 +663,28 @@ async function fetchSummary(opts: { contacts?: boolean } = {}) {
     : "http://localhost/api/groups/summary";
   const { GET } = await import("@/app/api/groups/summary/route");
   const res = await GET(new NextRequest(url));
+  return { status: res.status, data: await res.json() };
+}
+
+async function postSettlement(
+  groupId: string,
+  payerMemberId: string,
+  receiverMemberId: string,
+  amount: number,
+) {
+  const { POST } = await import("@/app/api/settlements/route");
+  const res = await POST(
+    new NextRequest("http://localhost/api/settlements", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        groupId,
+        payerMemberId,
+        receiverMemberId,
+        amount,
+      }),
+    }),
+  );
   return { status: res.status, data: await res.json() };
 }
 
@@ -937,31 +1061,46 @@ describe("expense & settlement flows", () => {
     });
   });
 
-  // ── Flow 10: Settle more than owed is capped ──
+  // ── Flow 10: Settlement cap via API (race-safe RPC mock) ──
 
-  describe("Flow 10: over-settlement produces correct net", () => {
-    it("over-paying flips the balance direction", async () => {
+  describe("Flow 10: settlement cap via POST /api/settlements", () => {
+    it("caps over-payment to remaining debt", async () => {
       const gid = addGroup("Overpay");
       const me = addMember(gid, "Me", { userId: TEST_USER_ID });
       const alice = addMember(gid, "Alice");
 
-      // I pay $100, split equally → I'm owed $50
       addExpenseDirectly(gid, me, 100, [
         { memberId: me, amount: 50 },
         { memberId: alice, amount: 50 },
       ]);
 
-      // Alice "settles" $70 (more than owed)
-      addSettlementDirectly(gid, alice, me, 70);
+      const res = await postSettlement(gid, alice, me, 70);
+      expect(res.status).toBe(200);
+      expect(res.data.amount).toBe(50);
 
       const detail = await fetchGroupDetail(gid);
       const balances = detail.data.balances as Array<{ memberId: string; total: number }>;
-
-      // Me: 100 - 50 - 70 = -20 (now I owe Alice!)
-      // Alice: 0 - 50 + 70 = 20
-      expect(balances.find((b) => b.memberId === me)?.total).toBe(-20);
-      expect(balances.find((b) => b.memberId === alice)?.total).toBe(20);
+      expect(balances.find((b) => b.memberId === me)?.total ?? 0).toBe(0);
+      expect(balances.find((b) => b.memberId === alice)?.total ?? 0).toBe(0);
       expect(sumBalances(balances)).toBe(0);
+    });
+
+    it("rejects duplicate full settle (double-tap)", async () => {
+      const gid = addGroup("Double tap");
+      const me = addMember(gid, "Me", { userId: TEST_USER_ID });
+      const alice = addMember(gid, "Alice");
+
+      addExpenseDirectly(gid, me, 100, [
+        { memberId: me, amount: 50 },
+        { memberId: alice, amount: 50 },
+      ]);
+
+      const first = await postSettlement(gid, alice, me, 50);
+      expect(first.status).toBe(200);
+
+      const second = await postSettlement(gid, alice, me, 50);
+      expect(second.status).toBe(400);
+      expect(second.data.error).toMatch(/Already settled|Nothing left/i);
     });
   });
 

--- a/app/api/__tests__/expense-settlement-flows.test.ts
+++ b/app/api/__tests__/expense-settlement-flows.test.ts
@@ -219,18 +219,33 @@ function rpcHandler(
     return { data: { updated: true }, error: null };
   }
 
-  if (fnName === "insert_settlement_checked") {
+  if (fnName === "insert_settlement_checked" || fnName === "insert_stripe_settlement_checked") {
     const groupId = params.p_group_id as string;
-    const userId = params.p_clerk_user_id as string;
     const payerMemberId = params.p_payer_member_id as string;
     const receiverMemberId = params.p_receiver_member_id as string;
     const amount = Number(params.p_amount);
     const currency = (params.p_currency as string) || "USD";
+    const externalRef = params.p_external_reference as string | undefined;
 
-    const myMember = db.group_members.find(
-      (m) => m.group_id === groupId && m.user_id === userId
-    );
-    if (!myMember) return { data: { error: "Not in group" }, error: null };
+    if (fnName === "insert_settlement_checked") {
+      const userId = params.p_clerk_user_id as string;
+      const myMember = db.group_members.find(
+        (m) => m.group_id === groupId && m.user_id === userId
+      );
+      if (!myMember) return { data: { error: "Forbidden" }, error: null };
+    }
+
+    if (externalRef) {
+      const existing = db.settlements.find(
+        (s) => (s as { external_reference?: string }).external_reference === externalRef
+      );
+      if (existing) {
+        return {
+          data: { ...existing, already_exists: true },
+          error: null,
+        };
+      }
+    }
 
     const settId = nextId("set");
     db.settlements.push({
@@ -241,12 +256,12 @@ function rpcHandler(
       amount,
       iso_currency_code: currency,
       status: "completed",
-      method: "manual",
+      method: fnName === "insert_stripe_settlement_checked" ? "stripe" : "manual",
       created_at: new Date().toISOString(),
-      created_by: userId,
+      ...(externalRef ? { external_reference: externalRef } : {}),
     });
 
-    return { data: { id: settId }, error: null };
+    return { data: { id: settId, amount }, error: null };
   }
 
   return { data: null, error: { message: `Unknown RPC: ${fnName}` } };

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@clerk/nextjs/server";
 import { getSupabase } from "@/lib/supabase";
 import { search } from "@/lib/search-engine";
 import { chatWithContext } from "@/lib/openai";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimitAsync } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
   // Parallelize auth + body parse (independent)
@@ -14,7 +14,7 @@ export async function POST(request: NextRequest) {
   ]);
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const rl = rateLimit(`chat:${userId}`, 20, 60_000);
+  const rl = await rateLimitAsync(`chat:${userId}`, 20, 60_000);
   if (!rl.success) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }

--- a/app/api/debug/me/route.ts
+++ b/app/api/debug/me/route.ts
@@ -1,16 +1,16 @@
 export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { debugEndpointDisabledResponse } from "@/lib/debug-guard";
 
 /**
  * GET /api/debug/me
  * Returns your Clerk user ID when authenticated.
- * Disabled in production builds.
+ * Requires ENABLE_DEBUG_ENDPOINTS=true.
  */
 export async function GET() {
-  if (process.env.ENABLE_DEBUG_ENDPOINTS !== "true") {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  const disabled = debugEndpointDisabledResponse();
+  if (disabled) return disabled;
   const { userId } = await auth();
   return NextResponse.json(
     { userId: userId ?? null },

--- a/app/api/debug/receipt-match-verify/route.ts
+++ b/app/api/debug/receipt-match-verify/route.ts
@@ -7,16 +7,18 @@ import { getSupabaseForUser } from "@/lib/supabase";
 import { fetchAllEmailReceiptsLinkedForUser } from "@/lib/transaction-sync";
 import { extractKeywords, normalizeMerchant, scoreCandidates, merchantsMatch } from "@/lib/receipt-matcher";
 import { RECEIPT_MATCH } from "@/lib/config";
+import { debugEndpointDisabledResponse } from "@/lib/debug-guard";
 
 /**
  * GET /api/debug/receipt-match-verify
  *
- * Diagnostic endpoint that compares what the email-receipts page sees
- * (admin client) vs what the transactions page sees (user-scoped client).
- *
- * DELETE THIS AFTER DEBUGGING.
+ * Diagnostic: compares admin vs user-scoped receipt visibility.
+ * Requires ENABLE_DEBUG_ENDPOINTS=true (disabled in production).
  */
 export async function GET() {
+  const disabled = debugEndpointDisabledResponse();
+  if (disabled) return disabled;
+
   const session = await loadClerkAuth();
   if (!session.ok) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/debug/rls/route.ts
+++ b/app/api/debug/rls/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { getSupabaseAdmin, getSupabaseForUser } from "@/lib/supabase";
+import { debugEndpointDisabledResponse } from "@/lib/debug-guard";
  
 /**
  * GET /api/debug/rls
@@ -11,9 +12,8 @@ import { getSupabaseAdmin, getSupabaseForUser } from "@/lib/supabase";
  * - If RLS is configured correctly, it should only return rows for the requesting user.
  */
 export async function GET() {
-  if (process.env.ENABLE_DEBUG_ENDPOINTS !== "true") {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  const disabled = debugEndpointDisabledResponse();
+  if (disabled) return disabled;
  
   const { userId, getToken } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/health — lightweight readiness probe (no auth).
+ * Does not call external services to avoid rate limits; checks config presence only.
+ */
+export async function GET() {
+  const checks = {
+    supabaseUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+    supabaseServiceKey: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY),
+    clerk: Boolean(process.env.CLERK_SECRET_KEY),
+    plaid: Boolean(process.env.PLAID_CLIENT_ID),
+    plaidEnv: process.env.PLAID_ENV ?? "sandbox",
+    cronSecret: Boolean(process.env.CRON_SECRET),
+    tokenEncryption: Boolean(process.env.TOKEN_ENCRYPTION_KEY?.trim()),
+    revenueCatWebhook: Boolean(process.env.REVENUECAT_WEBHOOK_SECRET?.trim()),
+  };
+
+  const production = process.env.NODE_ENV === "production";
+  const criticalOk =
+    checks.supabaseUrl &&
+    checks.supabaseServiceKey &&
+    checks.clerk &&
+    (!production || (checks.cronSecret && checks.tokenEncryption));
+
+  return NextResponse.json(
+    {
+      ok: criticalOk,
+      env: process.env.NODE_ENV ?? "development",
+      checks,
+    },
+    {
+      status: criticalOk ? 200 : 503,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
+}

--- a/app/api/nl-search/__tests__/route.test.ts
+++ b/app/api/nl-search/__tests__/route.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/lib/demo", () => ({
   getEffectiveUserId: vi.fn().mockResolvedValue("user_test_123"),
 }));
 vi.mock("@/lib/rate-limit", () => ({
-  rateLimit: vi.fn().mockReturnValue({ success: true }),
+  rateLimitAsync: vi.fn().mockResolvedValue({ success: true, remaining: 19 }),
 }));
 vi.mock("@/lib/search-engine", () => ({
   search: vi.fn().mockResolvedValue({

--- a/app/api/nl-search/route.ts
+++ b/app/api/nl-search/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import { search } from "@/lib/search-engine";
 import { getEffectiveUserId } from "@/lib/demo";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimitAsync } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
   const [effectiveUserId, body] = await Promise.all([
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const rl = rateLimit(`nl-search:${effectiveUserId}`, 20, 60_000);
+  const rl = await rateLimitAsync(`nl-search:${effectiveUserId}`, 20, 60_000);
   if (!rl.success) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }

--- a/app/api/plaid/create-link-token/route.ts
+++ b/app/api/plaid/create-link-token/route.ts
@@ -5,7 +5,7 @@ import { getPlaidConfig } from "@/lib/plaid";
 import { Products, CountryCode } from "plaid";
 import { getEffectiveUserId } from "@/lib/demo";
 import { SYNC } from "@/lib/config";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimitAsync } from "@/lib/rate-limit";
 import { NextRequest } from "next/server";
 
 type CreateLinkBody = {
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Sign in to connect your bank", trace_id: traceId }, { status: 401 });
   }
 
-  const rl = rateLimit(`plaid-link:${effectiveUserId}`, 30, 60_000);
+  const rl = await rateLimitAsync(`plaid-link:${effectiveUserId}`, 30, 60_000);
   if (!rl.success) {
     console.warn("[plaid][create-link-token] rate_limited", { trace_id: traceId, user_id: effectiveUserId });
     return NextResponse.json({ error: "Too many requests", trace_id: traceId }, { status: 429 });

--- a/app/api/plaid/debug/route.ts
+++ b/app/api/plaid/debug/route.ts
@@ -5,6 +5,7 @@ import { getEffectiveUserId } from "@/lib/demo";
 import { getSupabase } from "@/lib/supabase";
 import { getAllPlaidTokensForUser } from "@/lib/transaction-sync";
 import { getPlaidClient } from "@/lib/plaid-client";
+import { debugEndpointDisabledResponse } from "@/lib/debug-guard";
 
 const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID;
 const PLAID_SANDBOX_SECRET = process.env.PLAID_SANDBOX_SECRET;
@@ -30,9 +31,8 @@ function createPlaidClientForEnv(env: "sandbox" | "production"): PlaidApi | null
  * GET /api/plaid/debug
  */
 export async function GET() {
-  if (process.env.ENABLE_DEBUG_ENDPOINTS !== "true") {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
+  const disabled = debugEndpointDisabledResponse();
+  if (disabled) return disabled;
   const effectiveUserId = await getEffectiveUserId();
   if (!effectiveUserId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/app/api/settlements/route.ts
+++ b/app/api/settlements/route.ts
@@ -55,14 +55,15 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const amountToInsert = Math.min(Math.round(amount * 100) / 100, maxAmount);
+  const requestedAmount = Math.round(amount * 100) / 100;
 
+  // JS pre-check for fast 400; RPC re-computes under advisory lock (race-safe cap).
   const { data: result, error: rpcErr } = await db.rpc("insert_settlement_checked", {
     p_clerk_user_id: userId,
     p_group_id: groupId,
     p_payer_member_id: payerMemberId,
     p_receiver_member_id: receiverMemberId,
-    p_amount: amountToInsert,
+    p_amount: requestedAmount,
     p_method: method,
     p_currency: currency,
   });
@@ -85,7 +86,29 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  if (typeof row.error === "string") {
+    const maxAmount =
+      typeof row.max_amount === "number"
+        ? row.max_amount
+        : typeof row.max_amount === "string"
+          ? Number(row.max_amount)
+          : undefined;
+    return NextResponse.json(
+      {
+        error: row.error,
+        ...(maxAmount !== undefined && Number.isFinite(maxAmount) ? { maxAmount } : {}),
+      },
+      { status: 400 },
+    );
+  }
+
   const settlementId = row.id;
+  const recordedAmount =
+    typeof row.amount === "number"
+      ? row.amount
+      : typeof row.amount === "string"
+        ? Number(row.amount)
+        : requestedAmount;
   if (typeof settlementId !== "string") {
     console.error("[settlements] insert_settlement_checked: missing id");
     return NextResponse.json({ error: "Operation failed" }, { status: 500 });
@@ -108,7 +131,7 @@ export async function POST(req: NextRequest) {
       void notifyGroupMembers(
         groupId,
         "Settlement recorded",
-        `${name} recorded a settlement of ${formatCurrency(amountToInsert, currency)}`,
+        `${name} recorded a settlement of ${formatCurrency(recordedAmount, currency)}`,
         userId,
         { type: "settlement", groupId, settlementId }
       );

--- a/app/api/webhooks/revenuecat/__tests__/route.test.ts
+++ b/app/api/webhooks/revenuecat/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const env = process.env;
+
+function makeRequest(body: unknown, authorization?: string): NextRequest {
+  return new NextRequest("http://localhost/api/webhooks/revenuecat", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(authorization ? { Authorization: authorization } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/webhooks/revenuecat", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...env };
+    vi.mock("@/lib/supabase", () => ({
+      getSupabaseAdmin: () => ({
+        from: () => ({
+          update: () => ({
+            eq: () => Promise.resolve({ error: null }),
+          }),
+        }),
+      }),
+    }));
+  });
+
+  afterEach(() => {
+    process.env = env;
+    vi.resetModules();
+  });
+
+  it("returns ok with subscriptions disabled when secret is unset", async () => {
+    delete process.env.REVENUECAT_WEBHOOK_SECRET;
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest({ event: { type: "INITIAL_PURCHASE" } }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, subscriptions: "disabled" });
+  });
+
+  it("returns 401 when Bearer token is wrong", async () => {
+    process.env.REVENUECAT_WEBHOOK_SECRET = "expected-secret";
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest(
+        { event: { type: "INITIAL_PURCHASE", app_user_id: "user_1" } },
+        "Bearer wrong",
+      ),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts valid Bearer when secret is configured", async () => {
+    process.env.REVENUECAT_WEBHOOK_SECRET = "expected-secret";
+    const { POST } = await import("../route");
+    const res = await POST(
+      makeRequest(
+        { event: { type: "INITIAL_PURCHASE", app_user_id: "user_1" } },
+        "Bearer expected-secret",
+      ),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/webhooks/revenuecat/route.ts
+++ b/app/api/webhooks/revenuecat/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase";
 
-const REVENUECAT_WEBHOOK_SECRET = process.env.REVENUECAT_WEBHOOK_SECRET ?? "";
+function getWebhookSecret(): string | undefined {
+  const secret = process.env.REVENUECAT_WEBHOOK_SECRET?.trim();
+  return secret || undefined;
+}
 
 /**
  * POST /api/webhooks/revenuecat
@@ -14,14 +17,20 @@ const REVENUECAT_WEBHOOK_SECRET = process.env.REVENUECAT_WEBHOOK_SECRET ?? "";
  *   - EXPIRATION, CANCELLATION, BILLING_ISSUE → tier = "free"
  *
  * See: https://www.revenuecat.com/docs/integrations/webhooks
+ *
+ * Optional: set REVENUECAT_WEBHOOK_SECRET when Pro subscriptions are enabled.
+ * Without it, events are acknowledged but tier is not updated (app stays free-tier).
  */
 export async function POST(req: NextRequest) {
-  if (REVENUECAT_WEBHOOK_SECRET) {
-    const authHeader = req.headers.get("authorization") ?? "";
-    if (authHeader !== `Bearer ${REVENUECAT_WEBHOOK_SECRET}`) {
-      console.warn("[revenuecat-webhook] Invalid auth header");
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const webhookSecret = getWebhookSecret();
+  if (!webhookSecret) {
+    return NextResponse.json({ ok: true, subscriptions: "disabled" });
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  if (authHeader !== `Bearer ${webhookSecret}`) {
+    console.warn("[revenuecat-webhook] Invalid auth header");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   let body: any;

--- a/app/app/error.tsx
+++ b/app/app/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Catches errors inside the authenticated app shell (/app/*).
+ */
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[app-error]", error);
+    }
+    // Wire @sentry/nextjs captureException here when SENTRY_DSN is configured.
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center p-6 bg-[#F5F3F2]">
+      <h2 className="text-lg font-semibold text-[#1e2021]">Something went wrong</h2>
+      <p className="mt-2 text-sm text-gray-600 text-center max-w-md">
+        This page hit an error. Your data is safe — try reloading this section.
+      </p>
+      <button
+        type="button"
+        onClick={() => reset()}
+        className="mt-6 px-5 py-2.5 bg-[#1e2021] hover:bg-[#161819] text-white text-sm font-medium rounded-xl"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * Catches errors in the root layout. Reports can be wired to Sentry when configured.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex flex-col items-center justify-center bg-[#F5F3F2] p-6 font-sans">
+        <h1 className="text-lg font-semibold text-[#1e2021]">Something went wrong</h1>
+        <p className="mt-2 text-sm text-gray-600 text-center max-w-md">
+          An unexpected error occurred. Try again or return to the home page.
+        </p>
+        {process.env.NODE_ENV !== "production" && error.message ? (
+          <pre className="mt-4 max-w-lg overflow-auto rounded-xl bg-white p-4 text-xs text-gray-700 border border-gray-200">
+            {error.message}
+          </pre>
+        ) : null}
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="px-5 py-2.5 bg-[#1e2021] hover:bg-[#161819] text-white text-sm font-medium rounded-xl"
+          >
+            Try again
+          </button>
+          <a
+            href="/"
+            className="px-5 py-2.5 border border-gray-200 text-[#1e2021] text-sm font-medium rounded-xl hover:bg-white"
+          >
+            Home
+          </a>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/components/AppGate.tsx
+++ b/components/AppGate.tsx
@@ -8,11 +8,15 @@ const SKIP_AUTH =
   process.env.NODE_ENV !== "production" &&
   process.env.NEXT_PUBLIC_SKIP_AUTH === "true";
 
-const CLERK_DISABLED = process.env.NEXT_PUBLIC_CLERK_DISABLED === "true";
+const CLERK_DISABLED =
+  process.env.NODE_ENV !== "production" &&
+  process.env.NEXT_PUBLIC_CLERK_DISABLED === "true";
 
 const BYPASS_AUTH = SKIP_AUTH || CLERK_DISABLED;
 
-export type PlaidStatus = "checking" | "linked" | "unlinked";
+const PLAID_STATUS_TIMEOUT_MS = 12_000;
+
+export type PlaidStatus = "checking" | "linked" | "unlinked" | "error";
 export const PlaidStatusContext = createContext<PlaidStatus>("checking");
 export const usePlaidStatus = () => useContext(PlaidStatusContext);
 
@@ -33,16 +37,25 @@ export function AppGate({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (BYPASS_AUTH || !isLoaded || !isSignedIn) return;
     let cancelled = false;
+    let resolved = false;
     const timeout = setTimeout(() => {
-      if (!cancelled) setPlaidStatus("unlinked");
-    }, 5000);
+      if (!cancelled && !resolved) setPlaidStatus("error");
+    }, PLAID_STATUS_TIMEOUT_MS);
     fetch("/api/plaid/status")
-      .then((res) => res.json())
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setPlaidStatus("error");
+          return null;
+        }
+        return res.json() as Promise<{ linked?: boolean }>;
+      })
       .then((data) => {
-        if (!cancelled) setPlaidStatus(data.linked ? "linked" : "unlinked");
+        if (cancelled || data == null) return;
+        resolved = true;
+        setPlaidStatus(data.linked ? "linked" : "unlinked");
       })
       .catch(() => {
-        if (!cancelled) setPlaidStatus("unlinked");
+        if (!cancelled) setPlaidStatus("error");
       })
       .finally(() => clearTimeout(timeout));
     return () => {
@@ -51,7 +64,7 @@ export function AppGate({ children }: { children: React.ReactNode }) {
     };
   }, [isLoaded, isSignedIn]);
 
-  // Redirect unlinked users to /connect (effect, not blocking render)
+  // Redirect only when Plaid confirms no bank link (not on network errors)
   useEffect(() => {
     if (plaidStatus === "unlinked") {
       router.replace("/connect");

--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -1,0 +1,108 @@
+# Coconut Production Runbook
+
+Operational guide for the Next.js backend (`coconut`) and companion mobile app (`coconut-app`). Use with `.env.example` and `docs/VERCEL_ENV_CHECKLIST.md`.
+
+## Environments
+
+| Environment | Web URL | Mobile API |
+|-------------|---------|------------|
+| Production | `https://coconut-app.dev` | `EXPO_PUBLIC_API_URL=https://coconut-app.dev` |
+| Local | `http://localhost:3000` | Same host or tunnel |
+
+## Pre-deploy checklist
+
+1. **Env vars** — All required vars in Vercel Production (see checklist below).
+2. **Supabase migrations** — Apply any new files under `supabase/migrations/` in the Supabase SQL editor (or CLI) **before** deploying code that depends on them.
+3. **Do not rely on migration-only Vercel skips** — If only SQL changed, still redeploy or confirm app version matches schema.
+4. **Redeploy** — `git push origin main` (pushes to both remotes per project convention).
+
+## Required Vercel variables (production)
+
+### Must have (app breaks or insecure without)
+
+- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`
+- `PLAID_CLIENT_ID`, `PLAID_PRODUCTION_SECRET`, `PLAID_ENV=production`
+- `TOKEN_ENCRYPTION_KEY` (32 bytes — Plaid tokens encrypted at rest)
+- `APP_URL=https://coconut-app.dev`
+- `CRON_SECRET` (Vercel crons return 401 without it)
+- `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`
+- `PAY_LINK_SIGNING_KEY`, `COLLECT_LINK_SIGNING_KEY` (or dedicated keys; not Clerk secret)
+
+### Must NOT be set in production
+
+- `ENABLE_DEBUG_ENDPOINTS=true`
+- `NEXT_PUBLIC_SKIP_AUTH=true`, `SKIP_AUTH=true`
+- `CLERK_DISABLED=true`, `NEXT_PUBLIC_CLERK_DISABLED=true`
+- `DEMO_ENABLED=true`
+
+### Strongly recommended
+
+- `CLERK_WEBHOOK_SIGNING_SECRET`
+- `OPENAI_API_KEY` (chat, search, receipts)
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
+- `GITHUB_BOT_TOKEN` (in-app bug reports)
+- `APPLE_TEAM_ID` (universal links)
+- `NEXT_PUBLIC_IOS_APP_URL`
+- `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` (when integrated)
+- `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` (optional — enables distributed rate limits on chat, nl-search, Plaid link)
+- `REVENUECAT_WEBHOOK_SECRET` (optional — Pro subscriptions; omit while app is free-only)
+
+## Verify crons (after deploy)
+
+```bash
+curl -sS -H "Authorization: Bearer $CRON_SECRET" \
+  "https://coconut-app.dev/api/cron/process-jobs"
+curl -sS -H "Authorization: Bearer $CRON_SECRET" \
+  "https://coconut-app.dev/api/cron/receipt-match"
+```
+
+Expect JSON success (not 401). In Vercel → Project → Cron Jobs, confirm invocations over 24h.
+
+Scheduled jobs (`vercel.json`):
+
+| Path | Schedule |
+|------|----------|
+| `/api/cron/process-jobs` | Every minute |
+| `/api/cron/receipt-match` | Daily 02:00 UTC |
+
+## Verify health (when `/api/health` exists)
+
+```bash
+curl -sS "https://coconut-app.dev/api/health"
+```
+
+## Database migrations
+
+1. Source of truth: `supabase/migrations/*.sql` (newest date prefix wins).
+2. Legacy one-offs may exist in `docs/supabase-migration-*.sql` — port into `supabase/migrations/` before relying on them in prod.
+3. RLS policies: ensure `docs/supabase-migration-rls-policies.sql` is applied if not yet in migrations track.
+
+Record last applied migration in your ops notes (e.g. `20260529_stripe_connect_details_submitted`).
+
+## Mobile release (coconut-app)
+
+1. EAS secrets for all `EXPO_PUBLIC_*` and native keys (never commit).
+2. Production build: `eas build --profile production --platform ios`
+3. After build, verify IPA entitlements: `aps-environment=production`, associated domains for `coconut-app.dev`.
+4. Submit: `eas submit --profile production --platform ios`
+5. Rebuild native app after backend breaking API or env changes.
+
+## Rollback
+
+- **Web:** Vercel → Deployments → Promote previous deployment.
+- **Mobile:** Ship previous TestFlight build; no OTA until `expo-updates` is configured.
+- **DB:** Migrations are forward-only; keep rollback SQL scripts for destructive changes.
+
+## Incident response
+
+1. Check Sentry (when enabled) and Vercel function logs.
+2. Confirm crons not 401 (missing `CRON_SECRET`).
+3. Confirm `PLAID_ENV=production` if bank linking fails after Link UI succeeds.
+4. Confirm `TOKEN_ENCRYPTION_KEY` set if Plaid exchange fails with encryption errors.
+
+## Related docs
+
+- `docs/VERCEL_ENV_CHECKLIST.md` — variable-by-variable checklist
+- `docs/SECURITY_AUDIT.md` — historical findings (verify against current code)
+- `AGENTS.md` — validation commands before PR

--- a/docs/SETTLEMENT_RACE_FIX.md
+++ b/docs/SETTLEMENT_RACE_FIX.md
@@ -26,12 +26,12 @@ The API route still calls `getMaxSettlementAllowed` first for a fast rejection; 
 
 ## Apply in Supabase
 
-Run in order:
+Run in order (you applied `20260601` + `20260602`; **still run `20260603` for Stripe/Tap to Pay**):
 
 ```text
 supabase/migrations/20260601_settlements_external_reference_unique.sql
 supabase/migrations/20260602_settlement_balance_cap_rpc.sql
-supabase/migrations/20260603_stripe_settlement_cap_rpc.sql
+supabase/migrations/20260603_stripe_settlement_cap_rpc.sql   ← required for Stripe path
 ```
 
 ## Verify

--- a/docs/SETTLEMENT_RACE_FIX.md
+++ b/docs/SETTLEMENT_RACE_FIX.md
@@ -1,0 +1,46 @@
+# Settlement race fix (over-settlement on double-tap)
+
+## Problem
+
+`POST /api/settlements` used to:
+
+1. Read pairwise balance in Node (`getMaxSettlementAllowed`)
+2. Insert via `insert_settlement_checked` (membership check only)
+
+Two parallel requests could both read the same remaining balance before either INSERT committed → **over-settlement**.
+
+## Fix (migration `20260602_settlement_balance_cap_rpc.sql`)
+
+1. **`get_pairwise_settlement_max`** — SQL version of `computePairwiseBalance(receiver, payer)` with Splitwise dedupe rules.
+2. **`insert_settlement_checked`** — inside one transaction:
+   - `pg_advisory_xact_lock` on `(group, payer, receiver, currency)` — serializes concurrent inserts for the same pair
+   - Recompute `v_max` from current DB rows
+   - `INSERT` `LEAST(requested_amount, v_max)` only
+   - Return `400`-style JSON `{ error, max_amount }` if nothing left
+
+The API route still calls `getMaxSettlementAllowed` first for a fast rejection; the RPC is the **source of truth**.
+
+## Stripe path
+
+`lib/stripe-settlement-record.ts` uses **`insert_stripe_settlement_checked`** (migration `20260603_stripe_settlement_cap_rpc.sql`): same lock + cap, plus idempotent `external_reference` and `ON CONFLICT` for duplicate webhooks.
+
+## Apply in Supabase
+
+Run in order:
+
+```text
+supabase/migrations/20260601_settlements_external_reference_unique.sql
+supabase/migrations/20260602_settlement_balance_cap_rpc.sql
+supabase/migrations/20260603_stripe_settlement_cap_rpc.sql
+```
+
+## Verify
+
+1. Two tabs: mark paid $50 twice quickly on the same pair — second request should return 400 with `Already settled…` or a capped `maxAmount` of ~0.
+2. Partial settle $30 then $30 on $50 debt — second should cap to $20.
+
+## Limits
+
+- Advisory lock scope is **per pair per currency per group** (not whole group).
+- SQL balance must stay in sync with `lib/group-balances.ts` when logic changes — add tests in `lib/__tests__/financial-math.test.ts` and consider a parity integration test.
+- After deploying code, run **`20260603`** in Supabase if you already applied `20260601`–`20260602`.

--- a/docs/VERCEL_ENV_CHECKLIST.md
+++ b/docs/VERCEL_ENV_CHECKLIST.md
@@ -1,31 +1,99 @@
 # Vercel Environment Variables Checklist
 
-Add these to your **coconut** project in Vercel → Settings → Environment Variables.
+Add these in **coconut** → Vercel → Settings → Environment Variables → **Production**.
 
-## Required for app + Plaid to work
+Mark each when set. See `.env.example` for descriptions and generation commands.
 
-| Variable | Value | You have? |
-|----------|-------|-----------|
-| `PLAID_ENV` | `production` | ❌ **ADD THIS** — without it, backend uses sandbox and ignores PLAID_PRODUCTION_SECRET |
-| `PLAID_CLIENT_ID` | (from Plaid Dashboard) | ✓ |
-| `PLAID_PRODUCTION_SECRET` | (starts with `pls_production_`) | ✓ |
-| `APP_URL` | `https://coconut-app.dev` | Add if missing — needed for Plaid redirect URI |
+## Core (required)
 
-## Gmail receipts (if you use Google OAuth)
+| Variable | Production value | Set? |
+|----------|------------------|------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL | ☐ |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key | ☐ |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role | ☐ |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk publishable | ☐ |
+| `CLERK_SECRET_KEY` | Clerk secret | ☐ |
+| `APP_URL` | `https://coconut-app.dev` | ☐ |
+| `PLAID_CLIENT_ID` | Plaid dashboard | ☐ |
+| `PLAID_PRODUCTION_SECRET` | `pls_production_*` | ☐ |
+| `PLAID_ENV` | **`production`** | ☐ |
+| `TOKEN_ENCRYPTION_KEY` | 32-byte key (`openssl rand -hex 32`) | ☐ |
+
+Without `PLAID_ENV=production`, production secret is ignored and bank linking uses sandbox behavior.
+
+## Crons & webhooks (required for production behavior)
+
+| Variable | Notes | Set? |
+|----------|-------|------|
+| `CRON_SECRET` | `openssl rand -hex 32` — Vercel crons auth | ☐ |
+| `STRIPE_WEBHOOK_SECRET` | Stripe dashboard webhook | ☐ |
+| `REVENUECAT_WEBHOOK_SECRET` | Optional — only when enabling paid Pro | ☐ |
+| `CLERK_WEBHOOK_SIGNING_SECRET` | Clerk user lifecycle webhooks | ☐ |
+
+## Payments & signed links
+
+| Variable | Notes | Set? |
+|----------|-------|------|
+| `STRIPE_SECRET_KEY` | Live or test per environment | ☐ |
+| `STRIPE_PUBLISHABLE_KEY` | For Connect embedded / mobile | ☐ |
+| `PAY_LINK_SIGNING_KEY` | Dedicated; not `CLERK_SECRET_KEY` | ☐ |
+| `COLLECT_LINK_SIGNING_KEY` | Dedicated; can match pay key in dev only | ☐ |
+| `STRIPE_WEBHOOK_SECRET_THIN` | Optional second Stripe endpoint | ☐ |
+
+## Gmail receipts (if enabled)
 
 | Variable | Value |
 |----------|--------|
+| `GOOGLE_CLIENT_ID` | Google Cloud OAuth client |
+| `GOOGLE_CLIENT_SECRET` | |
 | `GOOGLE_REDIRECT_URI` | `https://coconut-app.dev/api/gmail/callback` |
 
-Also add that **exact** URL under Google Cloud Console → **Credentials** → your OAuth 2.0 Client → **Authorized redirect URIs**.
+Add the same redirect URI in Google Cloud Console → Credentials → OAuth client.
 
-## Auth + DB (you have these)
+## Mobile & links
 
-- NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-- CLERK_SECRET_KEY
-- NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, NEXT_PUBLIC_SUPABASE_ANON_KEY
+| Variable | Notes | Set? |
+|----------|-------|------|
+| `APPLE_TEAM_ID` | Universal links (`942BUGUD75`) | ☐ |
+| `NEXT_PUBLIC_IOS_APP_URL` | App Store / TestFlight URL | ☐ |
+| `NEXT_PUBLIC_APP_URL` | Optional; metadata / absolute links | ☐ |
 
-## After adding PLAID_ENV
+## Optional features
 
-1. Redeploy: Vercel → Deployments → Redeploy latest
-2. Rebuild app: `cd coconut-app && npx expo run:ios --device`
+| Variable | When needed |
+|----------|-------------|
+| `OPENAI_API_KEY` | Chat, NL search, receipt parse |
+| `SPLITWISE_CLIENT_ID` / `SPLITWISE_CLIENT_SECRET` | Splitwise import |
+| `SPLITWISE_REDIRECT_URI` | Must match Splitwise OAuth app exactly |
+| `GITHUB_BOT_TOKEN` | In-app bug reports |
+| `TELEGRAM_BOT_TOKEN` / `TELEGRAM_WEBHOOK_SECRET` | Telegram bug bot |
+| `AUTO_PAYOUT_ENABLED` | Default on; set `false` to disable globally |
+| `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN` | Error monitoring |
+
+## Production safety — must be unset or false
+
+| Variable | Risk if set |
+|----------|-------------|
+| `ENABLE_DEBUG_ENDPOINTS` | Exposes `/api/debug/*` |
+| `NEXT_PUBLIC_SKIP_AUTH` / `SKIP_AUTH` | Bypasses auth (dev only) |
+| `CLERK_DISABLED` / `NEXT_PUBLIC_CLERK_DISABLED` | Broken auth state |
+| `DEMO_ENABLED` | Demo API in non-prod only; never in prod |
+
+## After changes
+
+1. **Redeploy** — Vercel → Deployments → Redeploy latest.
+2. **Verify crons** — See `docs/PRODUCTION_RUNBOOK.md`.
+3. **Rebuild iOS app** if API URL or auth-related public env changed:
+   ```bash
+   cd coconut-app && npx expo run:ios --device
+   ```
+
+## Quick verification
+
+```bash
+# Crons (replace with your CRON_SECRET)
+curl -H "Authorization: Bearer $CRON_SECRET" https://coconut-app.dev/api/cron/process-jobs
+
+# Plaid status (signed-in session required in browser)
+# Open https://coconut-app.dev/app after linking bank
+```

--- a/docs/supabase-migration-settlements-dedupe-external-ref.sql
+++ b/docs/supabase-migration-settlements-dedupe-external-ref.sql
@@ -1,0 +1,30 @@
+-- One-off: preview duplicate external_reference rows before applying
+-- supabase/migrations/20260601_settlements_external_reference_unique.sql
+--
+-- Run in Supabase SQL editor if the unique index migration failed with 23505.
+
+-- How many duplicates exist?
+SELECT external_reference, COUNT(*) AS cnt
+FROM settlements
+WHERE external_reference IS NOT NULL AND TRIM(external_reference) <> ''
+GROUP BY external_reference
+HAVING COUNT(*) > 1
+ORDER BY cnt DESC;
+
+-- Rows that would be deleted (keeps earliest created_at per key)
+WITH ranked AS (
+  SELECT
+    id,
+    external_reference,
+    amount,
+    group_id,
+    created_at,
+    ROW_NUMBER() OVER (
+      PARTITION BY external_reference
+      ORDER BY created_at ASC NULLS LAST, id ASC
+    ) AS rn
+  FROM settlements
+  WHERE external_reference IS NOT NULL
+    AND TRIM(external_reference) <> ''
+)
+SELECT * FROM ranked WHERE rn > 1 ORDER BY external_reference, created_at;

--- a/lib/__tests__/debug-guard.test.ts
+++ b/lib/__tests__/debug-guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { debugEndpointDisabledResponse } from "../debug-guard";
+
+describe("debugEndpointDisabledResponse", () => {
+  it("returns 404 when ENABLE_DEBUG_ENDPOINTS is not true", () => {
+    const prev = process.env.ENABLE_DEBUG_ENDPOINTS;
+    delete process.env.ENABLE_DEBUG_ENDPOINTS;
+    const res = debugEndpointDisabledResponse();
+    expect(res?.status).toBe(404);
+    if (prev !== undefined) process.env.ENABLE_DEBUG_ENDPOINTS = prev;
+  });
+
+  it("returns null when ENABLE_DEBUG_ENDPOINTS is true", () => {
+    const prev = process.env.ENABLE_DEBUG_ENDPOINTS;
+    process.env.ENABLE_DEBUG_ENDPOINTS = "true";
+    expect(debugEndpointDisabledResponse()).toBeNull();
+    if (prev !== undefined) process.env.ENABLE_DEBUG_ENDPOINTS = prev;
+    else delete process.env.ENABLE_DEBUG_ENDPOINTS;
+  });
+});

--- a/lib/__tests__/encryption.test.ts
+++ b/lib/__tests__/encryption.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("encryption", () => {
+  const env = process.env;
+  const testKeyHex = "a".repeat(64);
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...env, TOKEN_ENCRYPTION_KEY: testKeyHex };
+  });
+
+  afterEach(() => {
+    process.env = env;
+    vi.resetModules();
+  });
+
+  it("round-trips with a valid 32-byte hex key", async () => {
+    const { encryptToken, decryptToken } = await import("../encryption");
+    const plain = "access-sandbox-test-token";
+    const encrypted = encryptToken(plain);
+    expect(encrypted).not.toBe(plain);
+    expect(decryptToken(encrypted)).toBe(plain);
+  });
+
+  it("allows plaintext passthrough in development without key", async () => {
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const { encryptToken, decryptToken } = await import("../encryption");
+    const plain = "dev-only-token";
+    expect(encryptToken(plain)).toBe(plain);
+    expect(decryptToken(plain)).toBe(plain);
+    vi.unstubAllEnvs();
+  });
+
+  it("throws on encrypt in production without key", async () => {
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", "");
+    vi.stubEnv("NODE_ENV", "production");
+    const { encryptToken } = await import("../encryption");
+    expect(() => encryptToken("secret")).toThrow(/TOKEN_ENCRYPTION_KEY is required/);
+    vi.unstubAllEnvs();
+  });
+
+  it("throws on decrypt in production without key", async () => {
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", "");
+    vi.stubEnv("NODE_ENV", "production");
+    const { decryptToken } = await import("../encryption");
+    expect(() => decryptToken("anything")).toThrow(/TOKEN_ENCRYPTION_KEY is required/);
+    vi.unstubAllEnvs();
+  });
+});

--- a/lib/__tests__/expense-shares.test.ts
+++ b/lib/__tests__/expense-shares.test.ts
@@ -4,6 +4,10 @@ import {
   computeTwoWayShares,
   validateCustomShares,
   toCents,
+  computePercentShares,
+  computeSharesByRatio,
+  allocateCrossGroupSettlementPayments,
+  sumShareAmountsCents,
 } from "../expense-shares";
 
 describe("toCents", () => {
@@ -160,5 +164,43 @@ describe("validateCustomShares", () => {
       { memberId: "B", amount: 0.2 },
     ]);
     expect(result.valid).toBe(true);
+  });
+});
+
+describe("computePercentShares", () => {
+  it("sums to total for 3-way split", () => {
+    const shares = computePercentShares(10, [
+      { memberId: "a", percent: 33.3 },
+      { memberId: "b", percent: 33.3 },
+      { memberId: "c", percent: 33.4 },
+    ]);
+    expect(sumShareAmountsCents(shares)).toBe(1000);
+  });
+});
+
+describe("computeSharesByRatio", () => {
+  it("sums to total for 2:1:1 ratio", () => {
+    const shares = computeSharesByRatio(40, [
+      { memberId: "a", weight: 2 },
+      { memberId: "b", weight: 1 },
+      { memberId: "c", weight: 1 },
+    ]);
+    expect(sumShareAmountsCents(shares)).toBe(4000);
+    expect(shares[0].amount).toBe(20);
+  });
+});
+
+describe("allocateCrossGroupSettlementPayments", () => {
+  it("never exceeds bucket caps", () => {
+    const buckets = [
+      { groupId: "g1", payerMemberId: "p", receiverMemberId: "r", amountOwed: 7.5, currency: "USD" },
+      { groupId: "g2", payerMemberId: "p", receiverMemberId: "r", amountOwed: 12.5, currency: "USD" },
+    ];
+    const out = allocateCrossGroupSettlementPayments(10, buckets);
+    for (const row of out) {
+      const cap = buckets.find((b) => b.groupId === row.groupId)!.amountOwed;
+      expect(row.payAmount).toBeLessThanOrEqual(cap);
+    }
+    expect(sumShareAmountsCents(out.map((x) => ({ amount: x.payAmount })))).toBe(1000);
   });
 });

--- a/lib/__tests__/financial-math.test.ts
+++ b/lib/__tests__/financial-math.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from "vitest";
+import {
+  distributeExtras,
+  computePersonShares,
+  type ReceiptItem,
+  type Assignee,
+} from "../receipt-split";
+import {
+  computeEqualShares,
+  computePercentShares,
+  computeSharesByRatio,
+  computeTwoWayShares,
+  allocateCrossGroupSettlementPayments,
+  sumShareAmountsCents,
+  toCents,
+  validateCustomShares,
+} from "../expense-shares";
+import {
+  computeBalances,
+  computePairwiseBalance,
+  getSuggestedSettlements,
+} from "../split-balances";
+
+function item(id: string, name: string, total: number): ReceiptItem {
+  return { id, name, quantity: 1, unitPrice: total, totalPrice: total };
+}
+
+describe("receipt split invariants", () => {
+  it("distributeExtras: sum(finalPrice) === subtotal + tax + tip + fees", () => {
+    const items = [item("1", "A", 12.99), item("2", "B", 8.5), item("3", "C", 3.75)];
+    const subtotal = 25.24;
+    const tax = 2.27;
+    const tip = 5;
+    const result = distributeExtras(items, subtotal, tax, tip, 1.5);
+    const sumFinal = result.reduce((s, r) => s + r.finalPrice, 0);
+    expect(toCents(sumFinal)).toBe(toCents(subtotal + tax + tip + 1.5));
+  });
+
+  it("computePersonShares: per-item assignee totals sum to item finalPrice", () => {
+    const items = distributeExtras(
+      [item("1", "Pizza", 20), item("2", "Salad", 10)],
+      30,
+      3,
+      2,
+    );
+    const assignments = new Map<string, Assignee[]>([
+      ["1", [{ name: "Alice", memberId: "a" }, { name: "Bob", memberId: "b" }]],
+      ["2", [{ name: "Alice", memberId: "a" }, { name: "Bob", memberId: "b" }, { name: "Carol", memberId: "c" }]],
+    ]);
+    const shares = computePersonShares(items, assignments);
+    for (const row of items) {
+      const assignees = assignments.get(row.id) ?? [];
+      const names = new Set(assignees.map((a) => a.name.toLowerCase()));
+      let itemSum = 0;
+      for (const p of shares) {
+        if (!names.has(p.name.toLowerCase())) continue;
+        const line = p.items.find((i) => i.itemName === row.name);
+        if (line) itemSum += line.shareAmount;
+      }
+      expect(toCents(itemSum)).toBe(toCents(row.finalPrice));
+    }
+  });
+});
+
+describe("expense share invariants", () => {
+  const amounts = [0.01, 0.99, 1, 10, 10.01, 33.33, 100, 999.99];
+
+  it("computeEqualShares always sums to total (stress)", () => {
+    for (const amt of amounts) {
+      for (const n of [1, 2, 3, 4, 7, 11]) {
+        const ids = Array.from({ length: n }, (_, i) => `m${i}`);
+        const shares = computeEqualShares(amt, ids);
+        expect(sumShareAmountsCents(shares)).toBe(toCents(amt));
+      }
+    }
+  });
+
+  it("computePercentShares sums to total when percents are 100", () => {
+    const shares = computePercentShares(100, [
+      { memberId: "a", percent: 33.3 },
+      { memberId: "b", percent: 33.3 },
+      { memberId: "c", percent: 33.4 },
+    ]);
+    expect(sumShareAmountsCents(shares)).toBe(10000);
+  });
+
+  it("computeSharesByRatio sums to total", () => {
+    const shares = computeSharesByRatio(50, [
+      { memberId: "a", weight: 2 },
+      { memberId: "b", weight: 1 },
+      { memberId: "c", weight: 1 },
+    ]);
+    expect(sumShareAmountsCents(shares)).toBe(5000);
+  });
+
+  it("computeTwoWayShares sums to total", () => {
+    for (const amt of amounts) {
+      const shares = computeTwoWayShares(amt, "z", "a");
+      expect(sumShareAmountsCents(shares)).toBe(toCents(amt));
+    }
+  });
+
+  it("validateCustomShares uses cent tolerance", () => {
+    expect(
+      validateCustomShares(10.01, [
+        { memberId: "a", amount: 5.01 },
+        { memberId: "b", amount: 5 },
+      ]).valid,
+    ).toBe(true);
+  });
+});
+
+describe("cross-group settlement allocation", () => {
+  it("single bucket caps at amount owed", () => {
+    const out = allocateCrossGroupSettlementPayments(50, [
+      {
+        groupId: "g1",
+        payerMemberId: "p",
+        receiverMemberId: "r",
+        amountOwed: 12,
+        currency: "USD",
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].payAmount).toBe(12);
+  });
+
+  it("multi-bucket partial payment sums to payment and respects caps", () => {
+    const buckets = [
+      { groupId: "g1", payerMemberId: "p", receiverMemberId: "r", amountOwed: 20, currency: "USD" },
+      { groupId: "g2", payerMemberId: "p", receiverMemberId: "r", amountOwed: 30, currency: "USD" },
+    ];
+    const out = allocateCrossGroupSettlementPayments(25, buckets);
+    const paid = out.reduce((s, x) => s + x.payAmount, 0);
+    expect(toCents(paid)).toBe(2500);
+    for (const row of out) {
+      const cap = buckets.find((b) => b.groupId === row.groupId)!.amountOwed;
+      expect(row.payAmount).toBeLessThanOrEqual(cap + 0.001);
+    }
+  });
+
+  it("full pay across two groups covers both caps", () => {
+    const buckets = [
+      { groupId: "g1", payerMemberId: "p", receiverMemberId: "r", amountOwed: 20, currency: "USD" },
+      { groupId: "g2", payerMemberId: "p", receiverMemberId: "r", amountOwed: 30, currency: "USD" },
+    ];
+    const out = allocateCrossGroupSettlementPayments(50, buckets);
+    expect(sumShareAmountsCents(out.map((x) => ({ amount: x.payAmount })))).toBe(5000);
+    expect(out.find((x) => x.groupId === "g1")?.payAmount).toBe(20);
+    expect(out.find((x) => x.groupId === "g2")?.payAmount).toBe(30);
+  });
+});
+
+describe("group balance ledger invariants", () => {
+  it("computeBalances: group net totals sum to zero after balanced expense", () => {
+    const balances = computeBalances(
+      [{ member_id: "a", amount: 60 }],
+      [
+        { member_id: "a", amount: 20 },
+        { member_id: "b", amount: 20 },
+        { member_id: "c", amount: 20 },
+      ],
+      [],
+      [],
+    );
+    const sum = Array.from(balances.values()).reduce((s, m) => s + m.total, 0);
+    expect(Math.round(sum * 100)).toBe(0);
+  });
+
+  it("settlement reduces payer debt in pairwise balance", () => {
+    const splits = [{ id: "s1", payerMemberId: "a" as string | null }];
+    const shares = new Map([["s1", [{ member_id: "b", amount: 40 }]]]);
+    const currencyMap = new Map([["s1", "USD"]]);
+
+    const before = computePairwiseBalance("a", "b", splits, shares, [], currencyMap, "USD");
+    expect(before).toBe(40);
+
+    const after = computePairwiseBalance(
+      "a",
+      "b",
+      splits,
+      shares,
+      [{ payer_member_id: "b", receiver_member_id: "a", amount: 15, currency: "USD" }],
+      currencyMap,
+      "USD",
+    );
+    expect(after).toBe(25);
+  });
+
+  it("getSuggestedSettlements amounts match creditor/debtor totals", () => {
+    const balances = computeBalances(
+      [
+        { member_id: "a", amount: 100 },
+        { member_id: "b", amount: 0 },
+      ],
+      [
+        { member_id: "a", amount: 0 },
+        { member_id: "b", amount: 100 },
+      ],
+      [],
+      [],
+    );
+    const suggestions = getSuggestedSettlements(balances);
+    const totalFlow = suggestions.reduce((s, x) => s + x.amount, 0);
+    expect(Math.round(totalFlow * 100)).toBe(10000);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].fromMemberId).toBe("b");
+    expect(suggestions[0].toMemberId).toBe("a");
+  });
+});

--- a/lib/__tests__/link-signing-key.test.ts
+++ b/lib/__tests__/link-signing-key.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveLinkSigningKey } from "../link-signing-key";
+
+describe("resolveLinkSigningKey", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers dedicated key", () => {
+    expect(resolveLinkSigningKey("dedicated-key", ["TOKEN_ENCRYPTION_KEY"])).toBe(
+      "dedicated-key",
+    );
+  });
+
+  it("uses TOKEN_ENCRYPTION_KEY in production when dedicated unset", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("TOKEN_ENCRYPTION_KEY", "enc-key-32-chars-minimum-length!!");
+    expect(resolveLinkSigningKey(undefined, ["TOKEN_ENCRYPTION_KEY", "CLERK_SECRET_KEY"])).toBe(
+      "enc-key-32-chars-minimum-length!!",
+    );
+  });
+
+  it("does not use CLERK_SECRET_KEY in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_test_clerk");
+    expect(() =>
+      resolveLinkSigningKey(undefined, ["CLERK_SECRET_KEY"]),
+    ).toThrow(/missing/i);
+  });
+
+  it("allows CLERK_SECRET_KEY fallback in development", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("CLERK_SECRET_KEY", "sk_test_clerk");
+    expect(resolveLinkSigningKey(undefined, ["CLERK_SECRET_KEY"])).toBe("sk_test_clerk");
+  });
+});

--- a/lib/__tests__/stripe-settlement-record.test.ts
+++ b/lib/__tests__/stripe-settlement-record.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const rpcMock = vi.fn();
+
+vi.mock("../supabase", () => ({
+  getSupabase: () => ({
+    rpc: rpcMock,
+  }),
+}));
+
+import { recordStripeSettlement } from "../stripe-settlement-record";
+
+describe("recordStripeSettlement", () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+  });
+
+  const baseParams = {
+    groupId: "g1",
+    payerMemberId: "p1",
+    receiverMemberId: "r1",
+    amount: 50,
+    currency: "USD",
+    externalReference: "pi_123",
+    source: "terminal" as const,
+  };
+
+  it("calls insert_stripe_settlement_checked RPC", async () => {
+    rpcMock.mockResolvedValue({
+      data: { id: "s1", amount: 50 },
+      error: null,
+    });
+
+    const result = await recordStripeSettlement(baseParams);
+
+    expect(result).toEqual({ ok: true, amountRecorded: 50 });
+    expect(rpcMock).toHaveBeenCalledWith("insert_stripe_settlement_checked", {
+      p_group_id: "g1",
+      p_payer_member_id: "p1",
+      p_receiver_member_id: "r1",
+      p_amount: 50,
+      p_currency: "USD",
+      p_external_reference: "pi_123",
+    });
+  });
+
+  it("returns amountRecorded 0 when already_exists", async () => {
+    rpcMock.mockResolvedValue({
+      data: { id: "s1", amount: 50, already_exists: true },
+      error: null,
+    });
+
+    const result = await recordStripeSettlement(baseParams);
+
+    expect(result).toEqual({ ok: true, amountRecorded: 0 });
+  });
+
+  it("returns error when RPC returns cap failure", async () => {
+    rpcMock.mockResolvedValue({
+      data: { error: "Already settled between these members in this currency", max_amount: 0 },
+      error: null,
+    });
+
+    const result = await recordStripeSettlement(baseParams);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.error).toContain("Already settled");
+    }
+  });
+
+  it("returns error when RPC transport fails", async () => {
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "connection failed" },
+    });
+
+    const result = await recordStripeSettlement(baseParams);
+
+    expect(result).toEqual({ ok: false, status: 500, error: "DB insert failed" });
+  });
+});

--- a/lib/__tests__/stripe-settlement-record.test.ts
+++ b/lib/__tests__/stripe-settlement-record.test.ts
@@ -65,7 +65,7 @@ describe("recordStripeSettlement", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.status).toBe(500);
+      expect(result.status).toBe(400);
       expect(result.error).toContain("Already settled");
     }
   });

--- a/lib/collect-link-token.ts
+++ b/lib/collect-link-token.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { getAppUrl } from "./app-url";
+import { resolveLinkSigningKey } from "./link-signing-key";
 
 export type CollectLinkPayload = {
   v: 1;
@@ -11,15 +12,10 @@ export type CollectLinkPayload = {
 export const COLLECT_LINK_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function getHmacKey(): string {
-  const key =
-    process.env.COLLECT_LINK_SIGNING_KEY ||
-    process.env.PAY_LINK_SIGNING_KEY ||
-    process.env.TOKEN_ENCRYPTION_KEY ||
-    process.env.CLERK_SECRET_KEY;
-  if (!key) {
-    throw new Error("COLLECT_LINK_SIGNING_KEY or PAY_LINK_SIGNING_KEY must be set");
-  }
-  return key;
+  const dedicated =
+    process.env.COLLECT_LINK_SIGNING_KEY?.trim() ||
+    process.env.PAY_LINK_SIGNING_KEY?.trim();
+  return resolveLinkSigningKey(dedicated, ["TOKEN_ENCRYPTION_KEY", "CLERK_SECRET_KEY"]);
 }
 
 function signPayload(encoded: string): string {

--- a/lib/debug-guard.ts
+++ b/lib/debug-guard.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Debug/diagnostic API routes must set ENABLE_DEBUG_ENDPOINTS=true.
+ * In production this must remain unset so routes return 404.
+ */
+export function debugEndpointDisabledResponse(): NextResponse | null {
+  if (process.env.ENABLE_DEBUG_ENDPOINTS === "true") {
+    return null;
+  }
+  return NextResponse.json({ error: "Not found" }, { status: 404 });
+}

--- a/lib/encryption.ts
+++ b/lib/encryption.ts
@@ -4,10 +4,19 @@ const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
 
+export function isProductionEncryptionRequired(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
 function getKey(): Buffer {
-  const key = process.env.TOKEN_ENCRYPTION_KEY;
+  const key = process.env.TOKEN_ENCRYPTION_KEY?.trim();
   if (!key) {
-    // In development without a key, return plaintext (don't break local dev)
+    if (isProductionEncryptionRequired()) {
+      throw new Error(
+        "TOKEN_ENCRYPTION_KEY is required in production. Generate with: openssl rand -hex 32",
+      );
+    }
+    // Local dev without a key: plaintext passthrough (do not use in production)
     return Buffer.alloc(0);
   }
   // Support both raw hex keys and base64 keys
@@ -20,17 +29,11 @@ function getKey(): Buffer {
 
 /**
  * Encrypt a plaintext string. Returns base64-encoded ciphertext with IV and auth tag prepended.
- * If no encryption key is configured, returns the plaintext as-is (for local development).
+ * Without TOKEN_ENCRYPTION_KEY, returns plaintext (local development only).
  */
-let warnedMissingKey = false;
-
 export function encryptToken(plaintext: string): string {
   const key = getKey();
   if (key.length === 0) {
-    if (process.env.NODE_ENV === "production" && !warnedMissingKey) {
-      console.warn("[encryption] WARNING: TOKEN_ENCRYPTION_KEY is not set — tokens are stored in plaintext. Set this env var to enable AES-256-GCM encryption.");
-      warnedMissingKey = true;
-    }
     return plaintext;
   }
 

--- a/lib/expense-shares.ts
+++ b/lib/expense-shares.ts
@@ -42,8 +42,8 @@ export function validateCustomShares(
   amount: number,
   shares: Array<{ memberId: string; amount: number }>
 ): { valid: boolean; error?: string } {
-  const sum = shares.reduce((s, sh) => s + Number(sh.amount), 0);
-  if (Math.abs(sum - amount) > 0.01) {
+  const sumCents = shares.reduce((s, sh) => s + toCents(Number(sh.amount)), 0);
+  if (Math.abs(sumCents - toCents(amount)) > 1) {
     return { valid: false, error: `Shares must sum to $${amount.toFixed(2)}` };
   }
   const hasPositive = shares.some((s) => Number(s.amount) > 0);
@@ -51,4 +51,132 @@ export function validateCustomShares(
     return { valid: false, error: "At least one share must be positive" };
   }
   return { valid: true };
+}
+
+/** Sum of share amounts in cents (for invariant checks). */
+export function sumShareAmountsCents(shares: Array<{ amount: number }>): number {
+  return shares.reduce((s, sh) => s + toCents(Number(sh.amount)), 0);
+}
+
+/**
+ * Split total by percentage weights. Remainder cents go to first assignees (stable).
+ * Percent values need not be exactly 100 — weights are normalized.
+ */
+export function computePercentShares(
+  amount: number,
+  entries: Array<{ memberId: string; percent: number }>
+): { memberId: string; amount: number }[] {
+  if (entries.length === 0) return [];
+  const totalCents = toCents(amount);
+  const weightSum = entries.reduce((s, e) => s + Math.max(0, e.percent), 0);
+  if (weightSum <= 0 || totalCents <= 0) {
+    return entries.map((e) => ({ memberId: e.memberId, amount: 0 }));
+  }
+
+  const rawCents = entries.map((e) =>
+    Math.floor((totalCents * Math.max(0, e.percent)) / weightSum),
+  );
+  let allocated = rawCents.reduce((s, c) => s + c, 0);
+  const result = entries.map((e, i) => ({
+    memberId: e.memberId,
+    amount: rawCents[i] / 100,
+  }));
+
+  let idx = 0;
+  while (allocated < totalCents && idx < entries.length) {
+    result[idx].amount = Math.round((result[idx].amount + 0.01) * 100) / 100;
+    allocated += 1;
+    idx += 1;
+  }
+  return result;
+}
+
+/**
+ * Split total by ratio weights (e.g. shares 2:1:1). Remainder cents to first assignees.
+ */
+export function computeSharesByRatio(
+  amount: number,
+  entries: Array<{ memberId: string; weight: number }>
+): { memberId: string; amount: number }[] {
+  if (entries.length === 0) return [];
+  const totalCents = toCents(amount);
+  const weightSum = entries.reduce((s, e) => s + Math.max(0, e.weight), 0);
+  if (weightSum <= 0 || totalCents <= 0) {
+    return entries.map((e) => ({ memberId: e.memberId, amount: 0 }));
+  }
+
+  const rawCents = entries.map((e) =>
+    Math.floor((totalCents * Math.max(0, e.weight)) / weightSum),
+  );
+  let allocated = rawCents.reduce((s, c) => s + c, 0);
+  const result = entries.map((e, i) => ({
+    memberId: e.memberId,
+    amount: rawCents[i] / 100,
+  }));
+
+  let idx = 0;
+  while (allocated < totalCents && idx < entries.length) {
+    result[idx].amount = Math.round((result[idx].amount + 0.01) * 100) / 100;
+    allocated += 1;
+    idx += 1;
+  }
+  return result;
+}
+
+export type CrossGroupSettlementBucket = {
+  groupId: string;
+  payerMemberId: string;
+  receiverMemberId: string;
+  /** Maximum still owed in this group (cap). */
+  amountOwed: number;
+  currency: string;
+};
+
+export type CrossGroupSettlementPayment = CrossGroupSettlementBucket & {
+  payAmount: number;
+};
+
+const MIN_SETTLEMENT_CENTS = 1;
+
+/**
+ * Allocate a partial/full payment across multiple group settlement buckets.
+ * Never exceeds each bucket cap; last bucket absorbs cent remainder.
+ */
+export function allocateCrossGroupSettlementPayments(
+  paymentAmount: number,
+  buckets: CrossGroupSettlementBucket[],
+): CrossGroupSettlementPayment[] {
+  const active = buckets.filter((b) => toCents(b.amountOwed) >= MIN_SETTLEMENT_CENTS);
+  if (active.length === 0 || paymentAmount <= 0) return [];
+
+  const paymentCents = toCents(paymentAmount);
+
+  if (active.length === 1) {
+    const b = active[0];
+    const payCents = Math.min(toCents(b.amountOwed), paymentCents);
+    return [{ ...b, payAmount: payCents / 100 }];
+  }
+
+  const totalOwed = active.reduce((s, b) => s + b.amountOwed, 0);
+  const payCentsByIndex: number[] = [];
+  let allocatedCents = 0;
+
+  for (let i = 0; i < active.length; i++) {
+    const capCents = toCents(active[i].amountOwed);
+    let payCents: number;
+    if (i === active.length - 1) {
+      payCents = Math.min(capCents, paymentCents - allocatedCents);
+    } else {
+      const proportion =
+        totalOwed > 0 ? active[i].amountOwed / totalOwed : 1 / active.length;
+      payCents = Math.min(capCents, Math.floor(paymentCents * proportion));
+    }
+    payCents = Math.max(0, payCents);
+    payCentsByIndex.push(payCents);
+    allocatedCents += payCents;
+  }
+
+  return active
+    .map((b, i) => ({ ...b, payAmount: payCentsByIndex[i] / 100 }))
+    .filter((row) => row.payAmount >= MIN_SETTLEMENT_CENTS / 100);
 }

--- a/lib/link-signing-key.ts
+++ b/lib/link-signing-key.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolves HMAC keys for signed pay/collect links.
+ * Production must not fall back to CLERK_SECRET_KEY (rotation would invalidate links).
+ */
+
+export function resolveLinkSigningKey(
+  dedicatedEnv: string | undefined,
+  fallbackEnvNames: Array<"TOKEN_ENCRYPTION_KEY" | "CLERK_SECRET_KEY">,
+): string {
+  const dedicated = dedicatedEnv?.trim();
+  if (dedicated) return dedicated;
+
+  const isProduction = process.env.NODE_ENV === "production";
+
+  for (const name of fallbackEnvNames) {
+    if (isProduction && name === "CLERK_SECRET_KEY") continue;
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+
+  const hint = isProduction
+    ? "Set PAY_LINK_SIGNING_KEY / COLLECT_LINK_SIGNING_KEY or TOKEN_ENCRYPTION_KEY in production"
+    : "Set PAY_LINK_SIGNING_KEY or TOKEN_ENCRYPTION_KEY / CLERK_SECRET_KEY for local dev";
+  throw new Error(`Link signing key missing. ${hint}`);
+}

--- a/lib/pay-link-token.ts
+++ b/lib/pay-link-token.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { getAppUrl } from "./app-url";
+import { resolveLinkSigningKey } from "./link-signing-key";
 
 /** Signed pay-link payload — no server-side storage required. */
 export type PayLinkPayload = {
@@ -18,16 +19,10 @@ export type PayLinkPayload = {
 export const PAY_LINK_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 function getHmacKey(): string {
-  const key =
-    process.env.PAY_LINK_SIGNING_KEY ||
-    process.env.TOKEN_ENCRYPTION_KEY ||
-    process.env.CLERK_SECRET_KEY;
-  if (!key) {
-    throw new Error(
-      "PAY_LINK_SIGNING_KEY (or TOKEN_ENCRYPTION_KEY / CLERK_SECRET_KEY) must be set",
-    );
-  }
-  return key;
+  return resolveLinkSigningKey(process.env.PAY_LINK_SIGNING_KEY, [
+    "TOKEN_ENCRYPTION_KEY",
+    "CLERK_SECRET_KEY",
+  ]);
 }
 
 function signPayload(encoded: string): string {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,3 +1,6 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
 const store = new Map<string, number[]>();
 
 const CLEANUP_INTERVAL_MS = 60_000;
@@ -14,6 +17,7 @@ function cleanup(windowMs: number) {
   }
 }
 
+/** In-memory rate limit (per serverless instance). */
 export function rateLimit(
   key: string,
   limit: number,
@@ -28,4 +32,36 @@ export function rateLimit(
   timestamps.push(now);
   store.set(key, timestamps);
   return { success: true, remaining: limit - timestamps.length };
+}
+
+/**
+ * Distributed rate limit when UPSTASH_REDIS_REST_URL + TOKEN are set.
+ * Falls back to in-memory rateLimit otherwise.
+ */
+export async function rateLimitAsync(
+  key: string,
+  limit: number,
+  windowMs: number,
+): Promise<{ success: boolean; remaining: number }> {
+  const url = process.env.UPSTASH_REDIS_REST_URL?.trim();
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN?.trim();
+  if (!url || !token) {
+    return rateLimit(key, limit, windowMs);
+  }
+
+  try {
+    const redis = new Redis({ url, token });
+    const ratelimit = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(limit, `${windowMs} ms`),
+      prefix: "coconut-rl",
+    });
+    const { success, remaining } = await ratelimit.limit(key);
+    return { success, remaining: remaining ?? 0 };
+  } catch (e) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[rate-limit] Upstash failed, using in-memory fallback", e);
+    }
+    return rateLimit(key, limit, windowMs);
+  }
 }

--- a/lib/stripe-settlement-record.ts
+++ b/lib/stripe-settlement-record.ts
@@ -12,7 +12,13 @@ function parseRpcRow(
   }
   const row = result as RpcSettlementRow;
   if (typeof row.error === "string") {
-    const status = row.error === "external_reference required" ? 400 : 500;
+    const status =
+      row.error === "external_reference required" ||
+      row.error === "Already settled between these members in this currency" ||
+      row.error === "Amount too small" ||
+      row.error === "Invalid amount"
+        ? 400
+        : 500;
     return { ok: false, status, error: row.error };
   }
   if (typeof row.id !== "string") {

--- a/lib/stripe-settlement-record.ts
+++ b/lib/stripe-settlement-record.ts
@@ -1,11 +1,29 @@
 import { getSupabase } from "./supabase";
-import { getMaxSettlementAllowed } from "./group-balances";
 
 export type StripeSettlementSource = "terminal" | "payment_link";
 
+type RpcSettlementRow = Record<string, unknown>;
+
+function parseRpcRow(
+  result: unknown,
+): { ok: true; row: RpcSettlementRow } | { ok: false; status: number; error: string } {
+  if (result == null || typeof result !== "object" || Array.isArray(result)) {
+    return { ok: false, status: 500, error: "Unexpected RPC response" };
+  }
+  const row = result as RpcSettlementRow;
+  if (typeof row.error === "string") {
+    const status = row.error === "external_reference required" ? 400 : 500;
+    return { ok: false, status, error: row.error };
+  }
+  if (typeof row.id !== "string") {
+    return { ok: false, status: 500, error: "Missing settlement id" };
+  }
+  return { ok: true, row };
+}
+
 /**
  * Record a completed Stripe payment as a settlement.
- * Idempotent via external_reference. Caps amount to max allowed balance.
+ * Idempotent via external_reference. Amount capped under advisory lock (race-safe).
  */
 export async function recordStripeSettlement(params: {
   groupId: string;
@@ -18,49 +36,45 @@ export async function recordStripeSettlement(params: {
 }): Promise<{ ok: true; amountRecorded: number } | { ok: false; status: number; error: string }> {
   const db = getSupabase();
   const currency = params.currency.toUpperCase();
+  const requestedAmount = Math.round(params.amount * 100) / 100;
 
-  const { data: existing } = await db
-    .from("settlements")
-    .select("id")
-    .eq("external_reference", params.externalReference)
-    .maybeSingle();
-
-  if (existing) return { ok: true, amountRecorded: 0 };
-
-  const { maxAmount, allowed, reason } = await getMaxSettlementAllowed(
-    params.groupId,
-    params.payerMemberId,
-    params.receiverMemberId,
-    currency,
-  );
-
-  if (!allowed || maxAmount <= 0) {
-    console.error(`[stripe-settlement] not allowed (${params.source}):`, { allowed, maxAmount, reason });
-    return { ok: false, status: 500, error: "Settlement validation failed" };
-  }
-
-  const amountToInsert = Math.min(params.amount, maxAmount);
-  const { error } = await db.from("settlements").insert({
-    group_id: params.groupId,
-    payer_member_id: params.payerMemberId,
-    receiver_member_id: params.receiverMemberId,
-    amount: Math.round(amountToInsert * 100) / 100,
-    method: "stripe",
-    status: "completed",
-    external_reference: params.externalReference,
-    iso_currency_code: currency,
+  const { data: result, error: rpcErr } = await db.rpc("insert_stripe_settlement_checked", {
+    p_group_id: params.groupId,
+    p_payer_member_id: params.payerMemberId,
+    p_receiver_member_id: params.receiverMemberId,
+    p_amount: requestedAmount,
+    p_currency: currency,
+    p_external_reference: params.externalReference,
   });
 
-  if (error) {
-    console.error(`[stripe-settlement] insert failed (${params.source}):`, error);
+  if (rpcErr) {
+    console.error(`[stripe-settlement] RPC failed (${params.source}):`, rpcErr.message);
     return { ok: false, status: 500, error: "DB insert failed" };
   }
 
+  const parsed = parseRpcRow(result);
+  if (!parsed.ok) {
+    console.error(`[stripe-settlement] not allowed (${params.source}):`, parsed.error);
+    return { ok: false, status: parsed.status, error: parsed.error };
+  }
+
+  const { row } = parsed;
+  if (row.already_exists === true) {
+    return { ok: true, amountRecorded: 0 };
+  }
+
+  const recorded =
+    typeof row.amount === "number"
+      ? row.amount
+      : typeof row.amount === "string"
+        ? Number(row.amount)
+        : requestedAmount;
+
   console.log(`[stripe-settlement] recorded (${params.source})`, {
     group_id: params.groupId,
-    amount: amountToInsert,
+    amount: recorded,
     ref: params.externalReference,
   });
 
-  return { ok: true, amountRecorded: amountToInsert };
+  return { ok: true, amountRecorded: Number.isFinite(recorded) ? recorded : requestedAmount };
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -15,6 +15,7 @@ const isPublicRoute = createRouteMatcher([
   "/api/gmail/callback",
   "/api/demo",
   "/api/telegram-webhook",
+  "/api/health",
   // Splitwise redirects here from their site — Safari has no Clerk cookie; user id comes from signed OAuth state.
   "/api/splitwise/callback",
   // Mobile app handoff — returns HTML that meta-refreshes to the custom scheme deep link.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@stripe/react-stripe-js": "^6.4.0",
         "@stripe/stripe-js": "^9.7.0",
         "@supabase/supabase-js": "^2.98.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "googleapis": "^171.4.0",
         "heic-convert": "^2.1.0",
         "jose": "^6.2.1",
@@ -3620,6 +3622,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
@@ -10485,6 +10520,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.22.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@stripe/react-stripe-js": "^6.4.0",
     "@stripe/stripe-js": "^9.7.0",
     "@supabase/supabase-js": "^2.98.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "googleapis": "^171.4.0",
     "heic-convert": "^2.1.0",
     "jose": "^6.2.1",

--- a/scripts/vercel-should-skip-build.sh
+++ b/scripts/vercel-should-skip-build.sh
@@ -23,7 +23,12 @@ fi
 
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
-  if [[ "$f" == docs/* ]] || [[ "$f" == .github/* ]] || [[ "$f" == supabase/migrations/* ]] || [[ "$f" == *.md ]]; then
+  # Never skip when schema migrations change — deploy so ops know to apply SQL in Supabase.
+  if [[ "$f" == supabase/migrations/* ]]; then
+    echo "Migration changed: $f — running build"
+    exit 1
+  fi
+  if [[ "$f" == docs/* ]] || [[ "$f" == .github/* ]] || [[ "$f" == *.md ]]; then
     continue
   fi
   exit 1

--- a/supabase/migrations/20260601_settlements_external_reference_unique.sql
+++ b/supabase/migrations/20260601_settlements_external_reference_unique.sql
@@ -1,0 +1,21 @@
+-- Idempotent Stripe / Splitwise settlement recording.
+-- Step 1: remove duplicate external_reference rows (keeps earliest per key).
+-- Step 2: unique index so new duplicates cannot be inserted.
+
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY external_reference
+      ORDER BY created_at ASC NULLS LAST, id ASC
+    ) AS rn
+  FROM settlements
+  WHERE external_reference IS NOT NULL
+    AND TRIM(external_reference) <> ''
+)
+DELETE FROM settlements
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+CREATE UNIQUE INDEX IF NOT EXISTS settlements_external_reference_unique
+  ON settlements (external_reference)
+  WHERE external_reference IS NOT NULL AND external_reference <> '';

--- a/supabase/migrations/20260602_settlement_balance_cap_rpc.sql
+++ b/supabase/migrations/20260602_settlement_balance_cap_rpc.sql
@@ -1,0 +1,156 @@
+-- Atomic settlement cap: prevents over-settlement when two POST /api/settlements run concurrently.
+-- Mirrors lib/group-balances.ts + lib/split-balances.ts computePairwiseBalance (receiver ← payer).
+
+CREATE OR REPLACE FUNCTION get_pairwise_settlement_max(
+  p_group_id           uuid,
+  p_receiver_member_id uuid,
+  p_payer_member_id    uuid,
+  p_currency           text DEFAULT 'USD'
+) RETURNS numeric
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_currency  text := upper(trim(coalesce(p_currency, 'USD')));
+  v_is_sw     boolean := false;
+  v_expenses  numeric := 0;
+  v_settled   numeric := 0;
+BEGIN
+  SELECT (g.source = 'splitwise' AND g.external_id IS NOT NULL)
+    INTO v_is_sw
+  FROM groups g
+  WHERE g.id = p_group_id;
+
+  -- Deduped splits (tx: id for bank-linked; split: id for manual/SW rows)
+  WITH split_rows AS (
+    SELECT
+      st.id,
+      COALESCE(NULLIF(st.transaction_id::text, ''), 'split:' || st.id::text) AS dedupe_key,
+      COALESCE(st.payer_member_id, gm_tx.id) AS effective_payer,
+      upper(trim(coalesce(st.iso_currency_code, 'USD'))) AS cur
+    FROM split_transactions st
+    LEFT JOIN transactions t ON t.id = st.transaction_id
+    LEFT JOIN group_members gm_tx
+      ON gm_tx.group_id = st.group_id AND gm_tx.user_id = t.clerk_user_id
+    WHERE st.group_id = p_group_id
+      AND (NOT v_is_sw OR st.source IS DISTINCT FROM 'splitwise')
+  ),
+  deduped AS (
+    SELECT DISTINCT ON (dedupe_key) id, effective_payer, cur
+    FROM split_rows
+    WHERE cur = v_currency
+    ORDER BY dedupe_key, id
+  )
+  SELECT coalesce(sum(
+    CASE
+      WHEN d.effective_payer = p_receiver_member_id AND ss.member_id = p_payer_member_id
+        THEN ss.amount
+      WHEN d.effective_payer = p_payer_member_id AND ss.member_id = p_receiver_member_id
+        THEN -ss.amount
+      ELSE 0
+    END
+  ), 0)
+  INTO v_expenses
+  FROM deduped d
+  JOIN split_shares ss ON ss.split_transaction_id = d.id;
+
+  SELECT coalesce(sum(
+    CASE
+      WHEN s.payer_member_id = p_receiver_member_id AND s.receiver_member_id = p_payer_member_id
+        THEN s.amount
+      WHEN s.payer_member_id = p_payer_member_id AND s.receiver_member_id = p_receiver_member_id
+        THEN -s.amount
+      ELSE 0
+    END
+  ), 0)
+  INTO v_settled
+  FROM settlements s
+  WHERE s.group_id = p_group_id
+    AND s.status = 'completed'
+    AND upper(trim(coalesce(s.iso_currency_code, 'USD'))) = v_currency
+    AND (NOT v_is_sw OR s.method IS DISTINCT FROM 'splitwise');
+
+  RETURN round(greatest(0, v_expenses + v_settled)::numeric, 2);
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION insert_settlement_checked(
+  p_clerk_user_id      text,
+  p_group_id           uuid,
+  p_payer_member_id    uuid,
+  p_receiver_member_id uuid,
+  p_amount             numeric,
+  p_method             text DEFAULT 'manual',
+  p_currency           text DEFAULT 'USD'
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_is_party        boolean;
+  v_max             numeric;
+  v_insert_amount   numeric;
+  v_id              uuid;
+  v_settlement      jsonb;
+  v_lock_key        bigint;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN jsonb_build_object('error', 'Invalid amount', 'max_amount', 0);
+  END IF;
+
+  -- Serialize concurrent settlements for the same pair + currency in this group
+  v_lock_key := hashtext(
+    p_group_id::text || '|' || p_payer_member_id::text || '|' ||
+    p_receiver_member_id::text || '|' || upper(trim(coalesce(p_currency, 'USD')))
+  );
+  PERFORM pg_advisory_xact_lock(v_lock_key);
+
+  SELECT EXISTS (
+    SELECT 1 FROM group_members
+     WHERE group_id = p_group_id
+       AND user_id  = p_clerk_user_id
+       AND id IN (p_payer_member_id, p_receiver_member_id)
+  ) INTO v_is_party;
+
+  IF NOT v_is_party THEN
+    RETURN jsonb_build_object('error', 'Forbidden');
+  END IF;
+
+  v_max := get_pairwise_settlement_max(
+    p_group_id, p_receiver_member_id, p_payer_member_id, p_currency
+  );
+
+  IF v_max < 0.01 THEN
+    RETURN jsonb_build_object(
+      'error', 'Already settled between these members in this currency',
+      'max_amount', v_max
+    );
+  END IF;
+
+  v_insert_amount := least(round(p_amount::numeric, 2), v_max);
+
+  IF v_insert_amount < 0.01 THEN
+    RETURN jsonb_build_object('error', 'Amount too small', 'max_amount', v_max);
+  END IF;
+
+  INSERT INTO settlements (
+    group_id, payer_member_id, receiver_member_id,
+    amount, method, status, iso_currency_code
+  ) VALUES (
+    p_group_id, p_payer_member_id, p_receiver_member_id,
+    v_insert_amount,
+    CASE WHEN p_method IN ('manual','in_person','online','stripe') THEN p_method ELSE 'manual' END,
+    'completed',
+    upper(trim(coalesce(p_currency, 'USD')))
+  ) RETURNING id INTO v_id;
+
+  SELECT to_jsonb(s) INTO v_settlement
+    FROM settlements s WHERE s.id = v_id;
+
+  RETURN v_settlement;
+END;
+$$;

--- a/supabase/migrations/20260603_stripe_settlement_cap_rpc.sql
+++ b/supabase/migrations/20260603_stripe_settlement_cap_rpc.sql
@@ -1,0 +1,111 @@
+-- Race-safe Stripe settlements: same advisory lock + balance cap as manual settlements.
+-- Idempotent on external_reference (webhook + terminal record-settlement duplicate calls).
+
+CREATE OR REPLACE FUNCTION insert_stripe_settlement_checked(
+  p_group_id            uuid,
+  p_payer_member_id     uuid,
+  p_receiver_member_id  uuid,
+  p_amount              numeric,
+  p_currency            text DEFAULT 'USD',
+  p_external_reference  text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_ref             text;
+  v_existing        jsonb;
+  v_max             numeric;
+  v_insert_amount   numeric;
+  v_id              uuid;
+  v_settlement      jsonb;
+  v_lock_key        bigint;
+BEGIN
+  v_ref := trim(coalesce(p_external_reference, ''));
+  IF v_ref = '' THEN
+    RETURN jsonb_build_object('error', 'external_reference required');
+  END IF;
+
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RETURN jsonb_build_object('error', 'Invalid amount', 'max_amount', 0);
+  END IF;
+
+  SELECT to_jsonb(s) || jsonb_build_object('already_exists', true)
+    INTO v_existing
+  FROM settlements s
+  WHERE s.external_reference = v_ref
+  LIMIT 1;
+
+  IF v_existing IS NOT NULL THEN
+    RETURN v_existing;
+  END IF;
+
+  v_lock_key := hashtext(
+    p_group_id::text || '|' || p_payer_member_id::text || '|' ||
+    p_receiver_member_id::text || '|' || upper(trim(coalesce(p_currency, 'USD')))
+  );
+  PERFORM pg_advisory_xact_lock(v_lock_key);
+
+  SELECT to_jsonb(s) || jsonb_build_object('already_exists', true)
+    INTO v_existing
+  FROM settlements s
+  WHERE s.external_reference = v_ref
+  LIMIT 1;
+
+  IF v_existing IS NOT NULL THEN
+    RETURN v_existing;
+  END IF;
+
+  v_max := get_pairwise_settlement_max(
+    p_group_id, p_receiver_member_id, p_payer_member_id, p_currency
+  );
+
+  IF v_max < 0.01 THEN
+    RETURN jsonb_build_object(
+      'error', 'Already settled between these members in this currency',
+      'max_amount', v_max
+    );
+  END IF;
+
+  v_insert_amount := least(round(p_amount::numeric, 2), v_max);
+
+  IF v_insert_amount < 0.01 THEN
+    RETURN jsonb_build_object('error', 'Amount too small', 'max_amount', v_max);
+  END IF;
+
+  INSERT INTO settlements (
+    group_id, payer_member_id, receiver_member_id,
+    amount, method, status, iso_currency_code, external_reference
+  ) VALUES (
+    p_group_id, p_payer_member_id, p_receiver_member_id,
+    v_insert_amount,
+    'stripe',
+    'completed',
+    upper(trim(coalesce(p_currency, 'USD'))),
+    v_ref
+  )
+  ON CONFLICT (external_reference) WHERE external_reference IS NOT NULL AND external_reference <> ''
+  DO NOTHING
+  RETURNING id INTO v_id;
+
+  IF v_id IS NULL THEN
+    SELECT to_jsonb(s) || jsonb_build_object('already_exists', true)
+      INTO v_existing
+    FROM settlements s
+    WHERE s.external_reference = v_ref
+    LIMIT 1;
+
+    IF v_existing IS NOT NULL THEN
+      RETURN v_existing;
+    END IF;
+
+    RETURN jsonb_build_object('error', 'Could not record settlement');
+  END IF;
+
+  SELECT to_jsonb(s) INTO v_settlement
+    FROM settlements s WHERE s.id = v_id;
+
+  RETURN v_settlement;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **Settlement race fix:** `insert_settlement_checked` and `insert_stripe_settlement_checked` RPCs cap amounts under `pg_advisory_xact_lock` using `get_pairwise_settlement_max`; manual `/api/settlements` and Stripe webhook/terminal paths use them.
- **Stripe idempotency:** unique `external_reference` index + RPC `ON CONFLICT` for duplicate webhooks.
- **Production hardening:** encryption/signing key guards, debug route gating, health endpoint, optional Upstash rate limits, RevenueCat webhook optional, docs/runbook updates, financial math tests.

## Supabase (required)
You already ran `20260601` and `20260602`. **Also run:**
```text
supabase/migrations/20260603_stripe_settlement_cap_rpc.sql
```

## Test plan
- [x] `npm run typecheck`, `lint`, `test` (685 tests)
- [ ] Double-tap "Mark paid" on same pair → second request 400
- [ ] Tap to Pay + webhook duplicate → single settlement row
- [ ] `/api/health` returns 200 on production after deploy


Made with [Cursor](https://cursor.com)